### PR TITLE
Add Guaranteed Lobber Ex Sweet Spot Setting & further RNG control

### DIFF
--- a/Cuphead.DebugMod/Components/GuaranteeLobberExSweetSpot.cs
+++ b/Cuphead.DebugMod/Components/GuaranteeLobberExSweetSpot.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Collections.Generic;
+using HarmonyLib;
+using UnityEngine;
+
+namespace BepInEx.CupheadDebugMod.Components;
+
+[HarmonyPatch]
+internal class GuaranteeLobberExSweetSpot {
+
+    // A Lobber Ex Sweet Spot is when a Lobber Ex collides in-between an enemy and a floor.
+    // Roughly half the times, it cause the explosion to happen twice. The other half, if will only happen once.
+    // This is due to OnCollisionEnemy() and OnCollisionGround() getting called in different orders seemingly at random (I think it's single-threaded code so not a true race condition).
+    // If OnCollisionEnemy() gets called first, then the double explosion will occur. If OnCollisionGround() gets called first, then it won't.
+    // The reason why is because OnCollisionGround() lacks a check to make sure to not cause an explosion if it has already happened, but OnCollisionEnemy() does have one.
+
+    [HarmonyPatch(typeof(WeaponBouncerProjectile), nameof(WeaponBouncerProjectile.Start))]
+    [HarmonyPrefix]
+    public static void StartFix(ref WeaponBouncerProjectile __instance) {
+        if (Config.Settings.GuaranteeLobberExSweetSpot.Value && __instance.isEx) {
+            weaponBouncerExtraProperties.SetProperty(__instance, "ranOnCollisionGroundOther", false);
+            weaponBouncerExtraProperties.SetProperty(__instance, "alreadyRanSweetSpotFix", false);
+        }
+    }
+
+    [HarmonyPatch(typeof(WeaponBouncerProjectile), nameof(WeaponBouncerProjectile.OnCollisionGround))]
+    [HarmonyPrefix]
+    public static void OnCollisionGroundFix(ref WeaponBouncerProjectile __instance) {
+        if (Config.Settings.GuaranteeLobberExSweetSpot.Value && __instance.isEx && !__instance.dead) {
+            weaponBouncerExtraProperties.SetProperty(__instance, "ranOnCollisionGroundOther", true);
+        }
+    }
+
+    [HarmonyPatch(typeof(WeaponBouncerProjectile), nameof(WeaponBouncerProjectile.OnCollisionEnemy))]
+    [HarmonyPrefix]
+    public static void OnCollisionEnemyFix(ref WeaponBouncerProjectile __instance) {
+        // Actual fix is here. If another collision type has been hit first, cause a second Lobber Ex explosion
+        if (Config.Settings.GuaranteeLobberExSweetSpot.Value && __instance.isEx && (bool)weaponBouncerExtraProperties.GetProperty(__instance, "ranOnCollisionGroundOther") && !(bool) weaponBouncerExtraProperties.GetProperty(__instance, "alreadyRanSweetSpotFix")) {
+            __instance.Die();
+            weaponBouncerExtraProperties.SetProperty(__instance, "alreadyRanSweetSpotFix", true);
+        }
+    }
+
+    [HarmonyPatch(typeof(WeaponBouncerProjectile), nameof(WeaponBouncerProjectile.OnCollisionOther))]
+    [HarmonyPrefix]
+    public static void OnCollisionOtherFix(ref WeaponBouncerProjectile __instance) {
+        if (Config.Settings.GuaranteeLobberExSweetSpot.Value && __instance.isEx && !__instance.dead) {
+            weaponBouncerExtraProperties.SetProperty(__instance, "ranOnCollisionGroundOther", true);
+        }
+    }
+
+    private static ExtraPropertyManager weaponBouncerExtraProperties = new ExtraPropertyManager();
+}
+
+
+
+
+// Utility class to essentially manage additional properties for WeaponBouncerProjectile at run-time
+// ConditionalWeakTable would've been more convenient, but it's not available on .NET 3.5
+public class ExtraPropertyManager {
+    private readonly Dictionary<WeakReference, Dictionary<string, object>> properties = new Dictionary<WeakReference, Dictionary<string, object>>();
+
+    public void SetProperty(object obj, string propertyName, object value) {
+        Cleanup();
+
+        var weakRef = GetWeakReference(obj);
+
+        if (!properties.ContainsKey(weakRef)) {
+            properties[weakRef] = new Dictionary<string, object>();
+        }
+
+        properties[weakRef][propertyName] = value;
+    }
+
+    public object GetProperty(object obj, string propertyName) {
+        Cleanup();
+
+        var weakRef = GetWeakReference(obj);
+
+        if (properties.TryGetValue(weakRef, out var objProperties)) {
+            if (objProperties.ContainsKey(propertyName)) {
+                return objProperties[propertyName];
+            }
+        }
+
+        return null;
+    }
+
+    private WeakReference GetWeakReference(object obj) {
+        foreach (var key in properties.Keys) {
+            if (key.Target == obj) {
+                return key;
+            }
+        }
+
+        return new WeakReference(obj);
+    }
+
+    private void Cleanup() {
+        var keysToRemove = new List<WeakReference>();
+
+        foreach (var key in properties.Keys) {
+            if (!key.IsAlive) {
+                keysToRemove.Add(key);
+            }
+        }
+
+        foreach (var key in keysToRemove) {
+            properties.Remove(key);
+        }
+    }
+}

--- a/Cuphead.DebugMod/Components/GuaranteeLobberExSweetSpot.cs
+++ b/Cuphead.DebugMod/Components/GuaranteeLobberExSweetSpot.cs
@@ -1,12 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using HarmonyLib;
-using UnityEngine;
 
 namespace BepInEx.CupheadDebugMod.Components;
 
 [HarmonyPatch]
 internal class GuaranteeLobberExSweetSpot {
+
 
     // A Lobber Ex Sweet Spot is when a Lobber Ex collides in-between an enemy and a floor.
     // Roughly half the times, it cause the explosion to happen twice. The other half, if will only happen once.
@@ -18,7 +18,7 @@ internal class GuaranteeLobberExSweetSpot {
     [HarmonyPrefix]
     public static void StartFix(ref WeaponBouncerProjectile __instance) {
         if (Config.Settings.GuaranteeLobberExSweetSpot.Value && __instance.isEx) {
-            weaponBouncerExtraProperties.SetProperty(__instance, "ranOnCollisionGroundOther", false);
+            weaponBouncerExtraProperties.SetProperty(__instance, "ranOnCollisionGround", false);
             weaponBouncerExtraProperties.SetProperty(__instance, "alreadyRanSweetSpotFix", false);
         }
     }
@@ -27,7 +27,7 @@ internal class GuaranteeLobberExSweetSpot {
     [HarmonyPrefix]
     public static void OnCollisionGroundFix(ref WeaponBouncerProjectile __instance) {
         if (Config.Settings.GuaranteeLobberExSweetSpot.Value && __instance.isEx && !__instance.dead) {
-            weaponBouncerExtraProperties.SetProperty(__instance, "ranOnCollisionGroundOther", true);
+            weaponBouncerExtraProperties.SetProperty(__instance, "ranOnCollisionGround", true);
         }
     }
 
@@ -35,17 +35,9 @@ internal class GuaranteeLobberExSweetSpot {
     [HarmonyPrefix]
     public static void OnCollisionEnemyFix(ref WeaponBouncerProjectile __instance) {
         // Actual fix is here. If another collision type has been hit first, cause a second Lobber Ex explosion
-        if (Config.Settings.GuaranteeLobberExSweetSpot.Value && __instance.isEx && (bool)weaponBouncerExtraProperties.GetProperty(__instance, "ranOnCollisionGroundOther") && !(bool) weaponBouncerExtraProperties.GetProperty(__instance, "alreadyRanSweetSpotFix")) {
+        if (Config.Settings.GuaranteeLobberExSweetSpot.Value && __instance.isEx && (bool) weaponBouncerExtraProperties.GetProperty(__instance, "ranOnCollisionGround") && !(bool) weaponBouncerExtraProperties.GetProperty(__instance, "alreadyRanSweetSpotFix")) {
             __instance.Die();
             weaponBouncerExtraProperties.SetProperty(__instance, "alreadyRanSweetSpotFix", true);
-        }
-    }
-
-    [HarmonyPatch(typeof(WeaponBouncerProjectile), nameof(WeaponBouncerProjectile.OnCollisionOther))]
-    [HarmonyPrefix]
-    public static void OnCollisionOtherFix(ref WeaponBouncerProjectile __instance) {
-        if (Config.Settings.GuaranteeLobberExSweetSpot.Value && __instance.isEx && !__instance.dead) {
-            weaponBouncerExtraProperties.SetProperty(__instance, "ranOnCollisionGroundOther", true);
         }
     }
 

--- a/Cuphead.DebugMod/Config/Settings.cs
+++ b/Cuphead.DebugMod/Config/Settings.cs
@@ -79,6 +79,7 @@ public class Settings : PluginComponent {
     public static ConfigEntry<DevilPhaseOneHeadTypes> DevilPhaseOneHeadType;
     public static ConfigEntry<DevilPhaseOneDragonDirections> DevilPhaseOneDragonDirection;
     public static ConfigEntry<DevilPhaseOneSpiderOffsets> DevilPhaseOneSpiderOffset;
+    public static ConfigEntry<DevilPhaseOneSpiderHopCounts> DevilPhaseOneSpiderHopCount;
     public static ConfigEntry<DevilPhaseOnePitchforkTypes> DevilPhaseOnePitchforkType;
     public static ConfigEntry<DevilPhaseTwoPatternsNormal> DevilPhaseTwoPatternNormal;
     public static ConfigEntry<DevilPhaseTwoPatternsHard> DevilPhaseTwoPatternHard;
@@ -169,6 +170,7 @@ public class Settings : PluginComponent {
         DevilPhaseOneHeadType = config.Bind("RNG The Devil", "Phase One Head Type", DevilPhaseOneHeadTypes.Random, --order);
         DevilPhaseOneDragonDirection = config.Bind("RNG The Devil", "Phase One Dragon Direction", DevilPhaseOneDragonDirections.Random, --order);
         DevilPhaseOneSpiderOffset = config.Bind("RNG The Devil", "Phase One Spider Offset", DevilPhaseOneSpiderOffsets.Random, --order);
+        DevilPhaseOneSpiderHopCount = config.Bind("RNG The Devil", "Phase One Spider Hop Count", DevilPhaseOneSpiderHopCounts.Random, --order);
         DevilPhaseOnePitchforkType = config.Bind("RNG The Devil", "Phase One Pitchfork Type", DevilPhaseOnePitchforkTypes.Random, --order);
         DevilPhaseTwoPatternNormal = config.Bind("RNG The Devil", "Phase Two Regular", DevilPhaseTwoPatternsNormal.Random, --order);
         DevilPhaseTwoPatternHard = config.Bind("RNG The Devil", "Phase Two Expert", DevilPhaseTwoPatternsHard.Random, --order);

--- a/Cuphead.DebugMod/Config/Settings.cs
+++ b/Cuphead.DebugMod/Config/Settings.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using BepInEx.Configuration;
+using BepInEx.CupheadDebugMod.Components;
 using UnityEngine;
 using static BepInEx.CupheadDebugMod.Config.SettingsEnums;
 
@@ -15,6 +16,7 @@ public class Settings : PluginComponent {
     public static ConfigEntry<bool> RunInBackground;
     public static ConfigEntry<bool> IgnoreInputWhenLoseFocus;
     public static ConfigEntry<bool> SkipTitleScreen;
+    public static ConfigEntry<bool> GuaranteeLobberExSweetSpot;
     public static ConfigEntry<KeyboardShortcut> InvincibilityOneFight;
     public static ConfigEntry<KeyboardShortcut> Gain5ExCards;
     public static ConfigEntry<KeyboardShortcut> Gain1ExCard;
@@ -114,6 +116,7 @@ public class Settings : PluginComponent {
         InvincibilityOneFight = config.Bind("Misc", "Invincibility One Fight", new KeyboardShortcut(KeyCode.Alpha5), --order);
         ToggleFrameCounter = config.Bind("Misc", "Toggle FrameCounter", new KeyboardShortcut(KeyCode.F4), --order);
         SwapBetweenFrameLimit = config.Bind("Misc", "Swap Between Frame Limit", new KeyboardShortcut(KeyCode.F5), --order);
+        GuaranteeLobberExSweetSpot = config.Bind("Misc", "Guarantee Lobber Ex Sweet Spot", false, --order);
 
         ToggleAllPanels = config.Bind("Panel", "Toggle All Panels", new KeyboardShortcut(KeyCode.F2), --order);
         ToggleBetweenPanels = config.Bind("Panel", "Toggle Between Panels", new KeyboardShortcut(KeyCode.F3), --order);

--- a/Cuphead.DebugMod/Config/SettingsEnums.cs
+++ b/Cuphead.DebugMod/Config/SettingsEnums.cs
@@ -394,6 +394,18 @@ namespace BepInEx.CupheadDebugMod.Config {
             [Description("0")]
             T_0
         }
+
+        public enum DevilPhaseOneSpiderHopCounts {
+            Random,
+            [Description("3")]
+            Num_3,
+            [Description("4")]
+            Num_4,
+            [Description("5")]
+            Num_5
+
+        }
+
         public enum DevilPhaseTwoPatternsNormal {
             Random,
             BombEye01,


### PR DESCRIPTION
A "Lobber Ex Sweet Spot" (commonly called Lobber Double or Triple damage depending on the game version) can happen when a Lobber Ex hits in-between a floor and an enemy. This unfortunately seems to happen with roughly a 50% likelihood when firing it in the perfect position, depending on the order the game decides to process Enemy and Ground Collision.
This PR adds an option in the settings that guarantees getting this glitch every time when executed correctly.
Additionally, it also adds an option to control the Devil's Spider Hop Count under the RNG settings.

If merged, it would also be nice to update the [TAS Tools repository](https://github.com/DemoJameson/Cuphead.TAS) with this version of the Debug Mod, since it was my main reason to write the Lobber Ex setting: TASes will desync on Lobber EX Sweet Spot attempts with roughly a 50% likelihood each. I have confirmed that with this mod enabled, those sync issues go away.