### PR TITLE
Add more RNG Control & infoHUD changes

### DIFF
--- a/Cuphead.DebugMod/Components/CameraZoom.cs
+++ b/Cuphead.DebugMod/Components/CameraZoom.cs
@@ -1,7 +1,7 @@
 ﻿using BepInEx.CupheadDebugMod.Config;
 using UnityEngine.SceneManagement;
 
-namespace BepInEx.CupheadDebugMod.Components; 
+namespace BepInEx.CupheadDebugMod.Components;
 
 public class CameraZoom : PluginComponent {
     private AbstractCupheadGameCamera Camera => FindObjectOfType<AbstractCupheadGameCamera>();

--- a/Cuphead.DebugMod/Components/Extensions.cs
+++ b/Cuphead.DebugMod/Components/Extensions.cs
@@ -1,0 +1,73 @@
+﻿
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+
+namespace BepInEx.CupheadDebugMod.Components;
+
+internal static class VectorExtensions {
+    public static string ToSimpleString(this Vector2 vector2, int decimals = 2) {
+        return $"{vector2.x.ToFormattedString(decimals)}, {vector2.y.ToFormattedString(decimals)}";
+    }
+
+    public static string ToSimpleString(this Vector3 vector3, int decimals = 2) {
+        return $"{vector3.x.ToFormattedString(decimals)}, {vector3.y.ToFormattedString(decimals)}";
+    }
+}
+
+internal static class NumberExtensions {
+
+    const int FRAMERATE = 60;
+    public static string ToFormattedString(this float value, int decimals = 2) {
+        return ((double) value).ToFormattedString(decimals);
+    }
+
+    public static string ToFormattedString(this double value, int decimals = 2) {
+        return value.ToString($"F{decimals}");
+    }
+
+    public static int ToCeilingFrames(this float seconds) {
+        return (int) Math.Ceiling(seconds * FRAMERATE);
+    }
+
+    public static int ToFloorFrames(this float seconds) {
+        return (int) Math.Floor(seconds * FRAMERATE);
+    }
+}
+
+
+
+
+internal static class EnumerableExtensions {
+    public static bool IsEmpty<T>(this IEnumerable<T> enumerable) {
+        return !enumerable.Any();
+    }
+
+    public static bool IsNullOrEmpty<T>(this IEnumerable<T> enumerable) {
+        return enumerable == null || !enumerable.Any();
+    }
+
+    public static bool IsNotEmpty<T>(this IEnumerable<T> enumerable) {
+        return !enumerable.IsEmpty();
+    }
+
+    public static bool IsNotNullOrEmpty<T>(this IEnumerable<T> enumerable) {
+        return !enumerable.IsNullOrEmpty();
+    }
+
+    public static IEnumerable<T> SkipLast<T>(this IEnumerable<T> source, int n = 1) {
+        var it = source.GetEnumerator();
+        bool hasRemainingItems = false;
+        var cache = new Queue<T>(n + 1);
+
+        do {
+            if (hasRemainingItems = it.MoveNext()) {
+                cache.Enqueue(it.Current);
+                if (cache.Count > n)
+                    yield return cache.Dequeue();
+            }
+        } while (hasRemainingItems);
+    }
+}

--- a/Cuphead.DebugMod/Components/GameInfoHelper.cs
+++ b/Cuphead.DebugMod/Components/GameInfoHelper.cs
@@ -1,0 +1,290 @@
+﻿using System;
+using System.Collections.Generic;
+using HarmonyLib;
+using Mono.Cecil.Cil;
+using MonoMod.Cil;
+using UnityEngine;
+
+namespace BepInEx.CupheadDebugMod.Components;
+
+[HarmonyPatch]
+public class GameInfoHelper : PluginComponent {
+    private static Vector3? lastPlayerPosition;
+    private static string lastLevelName;
+    private static string lastTime;
+    private static string lastInfo;
+    private static int lastEventIndex;
+    private static float overDamage;
+    public static Dictionary<Weapon, int> weaponsTimer = new() {
+        { Weapon.level_weapon_spreadshot, 0 },
+        { Weapon.level_weapon_bouncer, 0 },
+        { Weapon.level_weapon_charge, 0 },
+        { Weapon.level_weapon_peashot, 0 },
+        { Weapon.level_weapon_homing, 0 },
+        { Weapon.level_weapon_boomerang, 0 },
+        { Weapon.plane_weapon_peashot, 0 },
+        { Weapon.plane_weapon_laser, 0 },
+        { Weapon.plane_weapon_bomb, 0 },
+#if v1_3
+        { Weapon.level_weapon_crackshot, 0 },
+        { Weapon.level_weapon_wide_shot, 0 },
+        { Weapon.level_weapon_upshot, 0 },
+        { Weapon.plane_chalice_weapon_3way, 0 },
+        { Weapon.plane_chalice_weapon_bomb, 0 },
+#endif
+    };
+    public static int onEXWeaponCooldown;
+    public static string onEXWeaponName;
+    private static Dictionary<Weapon, int> EXWeaponsTimer = new() {
+        { Weapon.level_weapon_spreadshot, 0 },
+        { Weapon.level_weapon_bouncer, 0 },
+        { Weapon.level_weapon_charge, 0 },
+        { Weapon.level_weapon_peashot, 0 },
+        { Weapon.level_weapon_homing, 0 },
+        { Weapon.level_weapon_boomerang, 0 },
+        { Weapon.plane_weapon_peashot, 0 },
+        { Weapon.plane_weapon_laser, 0 },
+        { Weapon.plane_weapon_bomb, 0 },
+#if v1_3
+        { Weapon.level_weapon_crackshot, 0 },
+        { Weapon.level_weapon_wide_shot, 0 },
+        { Weapon.level_weapon_upshot, 0 },
+        { Weapon.plane_chalice_weapon_3way, 0 },
+        { Weapon.plane_chalice_weapon_bomb, 0 },
+#endif
+    };
+    public static bool canUpdateEXWeaponsTimer = true;
+    public static int chargeFrames;
+    private static int exFireFrames;
+    private static int exDelayFrames;
+    private static int exPlaneFireFrames;
+    private static int exPlaneDelayFrames;
+    private static readonly List<string> infos = new();
+    private static readonly List<string> statuses = new();
+
+    [HarmonyPatch(typeof(AbstractLevelWeapon), nameof(AbstractLevelWeapon.fireWeapon_cr), MethodType.Enumerator)]
+    [HarmonyPatch(typeof(AbstractLevelWeapon), nameof(AbstractLevelWeapon.chargeFireWeapon_cr), MethodType.Enumerator)]
+    [HarmonyILManipulator]
+    private static void AbstractLevelWeaponFireWeaponCr(ILContext ilContext) {
+        ILCursor ilCursor = new(ilContext);
+
+        ilCursor.GotoNext(i => i.OpCode == OpCodes.Ldfld && i.Operand.ToString().EndsWith("::$this"));
+        object thisOperand = ilCursor.Next.Operand;
+        ilCursor.Goto(0);
+
+        ilCursor.GotoNext(i => i.OpCode == OpCodes.Ldfld && i.Operand.ToString().EndsWith("::mode"));
+        object modeOperand = ilCursor.Next.Operand;
+        ilCursor.Goto(0);
+
+        while (ilCursor.TryGotoNext(i => i.OpCode == OpCodes.Stfld && (i.Operand.ToString().Contains("::t") || i.Operand.ToString().Contains("<t>")))) {
+            ilCursor.Emit(OpCodes.Ldarg_0)
+                .Emit(OpCodes.Ldfld, thisOperand)
+                .Emit(OpCodes.Ldarg_0)
+                .Emit(OpCodes.Ldfld, modeOperand)
+                .EmitDelegate<Func<float, AbstractLevelWeapon, AbstractLevelWeapon.Mode, float>>((t, levelWeapon, mode) => {
+                    int frames = (levelWeapon.rapidFireRate - t).ToCeilingFrames();
+                    if (mode == AbstractLevelWeapon.Mode.Basic) {
+                        weaponsTimer[levelWeapon.id] = frames;
+                    } else {
+                        EXWeaponsTimer[levelWeapon.id] = frames;
+                    }
+
+                    return t;
+                });
+            ilCursor.Index++;
+        }
+    }
+
+    [HarmonyPatch(typeof(AbstractPlaneWeapon), nameof(AbstractPlaneWeapon.fireWeapon_cr), MethodType.Enumerator)]
+    [HarmonyILManipulator]
+    private static void AbstractPlaneWeaponFireWeaponCr(ILContext ilContext) {
+        ILCursor ilCursor = new(ilContext);
+
+        ilCursor.GotoNext(i => i.OpCode == OpCodes.Ldfld && i.Operand.ToString().EndsWith("::$this"));
+        object thisOperand = ilCursor.Next.Operand;
+
+        ilCursor.Goto(0);
+        while (ilCursor.TryGotoNext(i => i.OpCode == OpCodes.Stfld && (i.Operand.ToString().Contains("::t") || i.Operand.ToString().Contains("<t>")))) {
+            ilCursor.Emit(OpCodes.Ldarg_0)
+                .Emit(OpCodes.Ldfld, thisOperand)
+                .EmitDelegate<Func<float, AbstractPlaneWeapon, float>>((t, planeWeapon) => {
+                    Weapon weapon = planeWeapon.index switch {
+                        0 => Weapon.plane_weapon_peashot,
+                        1 => Weapon.plane_weapon_laser,
+                        2 => Weapon.plane_weapon_bomb,
+#if v1_3
+                        3 => Weapon.plane_chalice_weapon_3way,
+                        4 => Weapon.plane_chalice_weapon_bomb,
+#endif
+                        _ => Weapon.None
+                    };
+                    weaponsTimer[weapon] = (planeWeapon.rapidFireRate - t).ToCeilingFrames();
+                    return t;
+                });
+            ilCursor.Index++;
+        }
+    }
+
+    [HarmonyPatch(typeof(WeaponCharge), nameof(WeaponCharge.FixedUpdate))]
+    [HarmonyPostfix]
+    private static void WeaponChargeFixedUpdate(WeaponCharge __instance) {
+        chargeFrames =
+            (WeaponProperties.LevelWeaponCharge.Basic.timeStateThree - __instance.timeCharged).ToFloorFrames();
+        if (chargeFrames < 0) {
+            chargeFrames = 0;
+        }
+    }
+
+    [HarmonyPatch(typeof(LevelPlayerWeaponManager), nameof(LevelPlayerWeaponManager.StartEx))]
+    [HarmonyPostfix]
+    private static void LevelPlayerWeaponManagerStartEx() {
+        exDelayFrames = 34;
+        exFireFrames = 16;
+    }
+
+    [HarmonyPatch(typeof(PlanePlayerWeaponManager), nameof(PlanePlayerWeaponManager.StartEx))]
+    [HarmonyPostfix]
+    private static void PlanePlayerWeaponManagerStartEx() {
+        exPlaneDelayFrames = 54;
+        exPlaneFireFrames = 31;
+    }
+
+    [HarmonyPatch(typeof(AbstractLevelWeapon), nameof(AbstractLevelWeapon.fireProjectile))]
+    [HarmonyPostfix]
+    private static void GetExWeaponCooldown(AbstractLevelWeapon.Mode mode, AbstractLevelWeapon __instance) {
+        if (mode == AbstractLevelWeapon.Mode.Ex) {
+            onEXWeaponCooldown = weaponsTimer[__instance.id];
+            onEXWeaponName = GetWeaponName(__instance.id);
+        }
+    }
+
+    [HarmonyPatch(typeof(AbstractPlaneWeapon), nameof(AbstractLevelWeapon.BeginEx))]
+    [HarmonyPrefix]
+    private static void PrepareForGetPlaneExWeaponCooldown() {
+        canUpdateEXWeaponsTimer = true;
+    }
+
+    [HarmonyPatch(typeof(AbstractPlaneWeapon), nameof(AbstractLevelWeapon.fireProjectile))]
+    [HarmonyPostfix]
+    private static void GetPlaneExWeaponCooldown(AbstractPlaneWeapon.Mode mode, AbstractPlaneWeapon __instance) {
+        if (mode == AbstractPlaneWeapon.Mode.Ex) {
+            if (canUpdateEXWeaponsTimer) {
+                Weapon currentPlaneWeapon = __instance.index switch {
+                    0 => Weapon.plane_weapon_peashot,
+                    1 => Weapon.plane_weapon_laser,
+                    2 => Weapon.plane_weapon_bomb,
+#if v1_3
+                    3 => Weapon.plane_chalice_weapon_3way,
+                    4 => Weapon.plane_chalice_weapon_bomb,
+#endif
+                    _ => Weapon.None
+                };
+                onEXWeaponCooldown = weaponsTimer[currentPlaneWeapon];
+                onEXWeaponName = GetWeaponName(currentPlaneWeapon);
+                // this prevents the timer from immediately updating again after a minibomb EX
+                canUpdateEXWeaponsTimer = false;
+            }
+
+        }
+    }
+
+    private void Awake() {
+        HookHelper.ActiveSceneChanged(() => {
+            lastPlayerPosition = null;
+            lastLevelName = null;
+            lastTime = null;
+            lastInfo = null;
+            lastEventIndex = 0;
+            overDamage = 0;
+            weaponsTimer = new() {
+                { Weapon.level_weapon_spreadshot, 0 },
+                { Weapon.level_weapon_bouncer, 0 },
+                { Weapon.level_weapon_charge, 0 },
+                { Weapon.level_weapon_peashot, 0 },
+                { Weapon.level_weapon_homing, 0 },
+                { Weapon.level_weapon_boomerang, 0 },
+                { Weapon.plane_weapon_peashot, 0 },
+                { Weapon.plane_weapon_laser, 0 },
+                { Weapon.plane_weapon_bomb, 0 },
+#if v1_3
+                { Weapon.level_weapon_crackshot, 0 },
+                { Weapon.level_weapon_wide_shot, 0 },
+                { Weapon.level_weapon_upshot, 0 },
+                { Weapon.plane_chalice_weapon_3way, 0 },
+                { Weapon.plane_chalice_weapon_bomb, 0 },
+#endif
+            };
+            EXWeaponsTimer = new() {
+                { Weapon.level_weapon_spreadshot, 0 },
+                { Weapon.level_weapon_bouncer, 0 },
+                { Weapon.level_weapon_charge, 0 },
+                { Weapon.level_weapon_peashot, 0 },
+                { Weapon.level_weapon_homing, 0 },
+                { Weapon.level_weapon_boomerang, 0 },
+                { Weapon.plane_weapon_peashot, 0 },
+                { Weapon.plane_weapon_laser, 0 },
+                { Weapon.plane_weapon_bomb, 0 },
+#if v1_3
+                { Weapon.level_weapon_crackshot, 0 },
+                { Weapon.level_weapon_wide_shot, 0 },
+                { Weapon.level_weapon_upshot, 0 },
+                { Weapon.plane_chalice_weapon_3way, 0 },
+                { Weapon.plane_chalice_weapon_bomb, 0 },
+#endif
+            };
+            onEXWeaponCooldown = 0;
+            onEXWeaponName = "";
+            chargeFrames = 0;
+            exDelayFrames = 0;
+            exFireFrames = 0;
+            exPlaneDelayFrames = 0;
+            exPlaneFireFrames = 0;
+        });
+    }
+
+    private void Update() {
+        if (exDelayFrames > 0) {
+            exDelayFrames--;
+        }
+
+        if (exFireFrames > 0) {
+            exFireFrames--;
+        }
+
+        if (exPlaneDelayFrames > 0) {
+            exPlaneDelayFrames--;
+        }
+
+        if (exPlaneFireFrames > 0) {
+            exPlaneFireFrames--;
+        }
+    }
+
+    public static string GetWeaponName(Weapon weapon) {
+        return weapon switch {
+            Weapon.level_weapon_peashot => "Peashooter",
+            Weapon.level_weapon_spreadshot => "Spread",
+            Weapon.level_weapon_homing => "Chaser",
+            Weapon.level_weapon_bouncer => "Lobber",
+            Weapon.level_weapon_charge => "Charge",
+            Weapon.level_weapon_boomerang => "Roundabout",
+            Weapon.plane_weapon_peashot => "Peashooter",
+            Weapon.plane_weapon_bomb => "Bomb",
+#if v1_3
+            Weapon.level_weapon_crackshot => "Crackshot",
+            Weapon.level_weapon_wide_shot => "Converge",
+            Weapon.level_weapon_upshot => "TwistUp",
+            Weapon.plane_chalice_weapon_3way => "Peashooter",
+            Weapon.plane_chalice_weapon_bomb => "Bomb",
+#endif
+            _ => weapon.ToString().Replace("level_weapon_", ""),
+        };
+    }
+
+    public static string FormatTime(float time) {
+        TimeSpan timeSpan = TimeSpan.FromSeconds(time);
+        string formatted =
+            $"{timeSpan.Minutes.ToString().PadLeft(2, '0')}:{timeSpan.Seconds.ToString().PadLeft(2, '0')}.{timeSpan.Milliseconds.ToString().PadLeft(3, '0')}";
+        return $"{formatted}({time.ToCeilingFrames()})";
+    }
+}

--- a/Cuphead.DebugMod/Components/GameSpeed.cs
+++ b/Cuphead.DebugMod/Components/GameSpeed.cs
@@ -2,7 +2,7 @@
 using BepInEx.CupheadDebugMod.Config;
 using UnityEngine;
 
-namespace BepInEx.CupheadDebugMod.Components; 
+namespace BepInEx.CupheadDebugMod.Components;
 
 public class FrameAdvance : PluginComponent {
     private static string FormattedSpeed => (int) Math.Round(Time.timeScale * 100) + "%";

--- a/Cuphead.DebugMod/Components/GuaranteeLobberExSweetSpot.cs
+++ b/Cuphead.DebugMod/Components/GuaranteeLobberExSweetSpot.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Collections.Generic;
+using HarmonyLib;
+using UnityEngine;
+
+namespace BepInEx.CupheadDebugMod.Components;
+
+[HarmonyPatch]
+internal class GuaranteeLobberExSweetSpot {
+
+    // A Lobber Ex Sweet Spot is when a Lobber Ex collides in-between an enemy and a floor.
+    // Roughly half the times, it cause the explosion to happen twice. The other half, if will only happen once.
+    // This is due to OnCollisionEnemy() and OnCollisionGround() getting called in different orders seemingly at random (I think it's single-threaded code so not a true race condition).
+    // If OnCollisionEnemy() gets called first, then the double explosion will occur. If OnCollisionGround() gets called first, then it won't.
+    // The reason why is because OnCollisionGround() lacks a check to make sure to not cause an explosion if it has already happened, but OnCollisionEnemy() does have one.
+
+    [HarmonyPatch(typeof(WeaponBouncerProjectile), nameof(WeaponBouncerProjectile.Start))]
+    [HarmonyPrefix]
+    public static void StartFix(ref WeaponBouncerProjectile __instance) {
+        if (Config.Settings.GuaranteeLobberExSweetSpot.Value && __instance.isEx) {
+            weaponBouncerExtraProperties.SetProperty(__instance, "ranOnCollisionGroundOther", false);
+            weaponBouncerExtraProperties.SetProperty(__instance, "alreadyRanSweetSpotFix", false);
+        }
+    }
+
+    [HarmonyPatch(typeof(WeaponBouncerProjectile), nameof(WeaponBouncerProjectile.OnCollisionGround))]
+    [HarmonyPrefix]
+    public static void OnCollisionGroundFix(ref WeaponBouncerProjectile __instance) {
+        if (Config.Settings.GuaranteeLobberExSweetSpot.Value && __instance.isEx && !__instance.dead) {
+            weaponBouncerExtraProperties.SetProperty(__instance, "ranOnCollisionGroundOther", true);
+        }
+    }
+
+    [HarmonyPatch(typeof(WeaponBouncerProjectile), nameof(WeaponBouncerProjectile.OnCollisionEnemy))]
+    [HarmonyPrefix]
+    public static void OnCollisionEnemyFix(ref WeaponBouncerProjectile __instance) {
+        // Actual fix is here. If another collision type has been hit first, cause a second Lobber Ex explosion
+        if (Config.Settings.GuaranteeLobberExSweetSpot.Value && __instance.isEx && (bool)weaponBouncerExtraProperties.GetProperty(__instance, "ranOnCollisionGroundOther") && !(bool) weaponBouncerExtraProperties.GetProperty(__instance, "alreadyRanSweetSpotFix")) {
+            __instance.Die();
+            weaponBouncerExtraProperties.SetProperty(__instance, "alreadyRanSweetSpotFix", true);
+        }
+    }
+
+    [HarmonyPatch(typeof(WeaponBouncerProjectile), nameof(WeaponBouncerProjectile.OnCollisionOther))]
+    [HarmonyPrefix]
+    public static void OnCollisionOtherFix(ref WeaponBouncerProjectile __instance) {
+        if (Config.Settings.GuaranteeLobberExSweetSpot.Value && __instance.isEx && !__instance.dead) {
+            weaponBouncerExtraProperties.SetProperty(__instance, "ranOnCollisionGroundOther", true);
+        }
+    }
+
+    private static ExtraPropertyManager weaponBouncerExtraProperties = new ExtraPropertyManager();
+}
+
+
+
+
+// Utility class to essentially manage additional properties for WeaponBouncerProjectile at run-time
+// ConditionalWeakTable would've been more convenient, but it's not available on .NET 3.5
+public class ExtraPropertyManager {
+    private readonly Dictionary<WeakReference, Dictionary<string, object>> properties = new Dictionary<WeakReference, Dictionary<string, object>>();
+
+    public void SetProperty(object obj, string propertyName, object value) {
+        Cleanup();
+
+        var weakRef = GetWeakReference(obj);
+
+        if (!properties.ContainsKey(weakRef)) {
+            properties[weakRef] = new Dictionary<string, object>();
+        }
+
+        properties[weakRef][propertyName] = value;
+    }
+
+    public object GetProperty(object obj, string propertyName) {
+        Cleanup();
+
+        var weakRef = GetWeakReference(obj);
+
+        if (properties.TryGetValue(weakRef, out var objProperties)) {
+            if (objProperties.ContainsKey(propertyName)) {
+                return objProperties[propertyName];
+            }
+        }
+
+        return null;
+    }
+
+    private WeakReference GetWeakReference(object obj) {
+        foreach (var key in properties.Keys) {
+            if (key.Target == obj) {
+                return key;
+            }
+        }
+
+        return new WeakReference(obj);
+    }
+
+    private void Cleanup() {
+        var keysToRemove = new List<WeakReference>();
+
+        foreach (var key in properties.Keys) {
+            if (!key.IsAlive) {
+                keysToRemove.Add(key);
+            }
+        }
+
+        foreach (var key in keysToRemove) {
+            properties.Remove(key);
+        }
+    }
+}

--- a/Cuphead.DebugMod/Components/GuaranteeLobberExSweetSpot.cs
+++ b/Cuphead.DebugMod/Components/GuaranteeLobberExSweetSpot.cs
@@ -1,12 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using HarmonyLib;
-using UnityEngine;
 
 namespace BepInEx.CupheadDebugMod.Components;
 
 [HarmonyPatch]
 internal class GuaranteeLobberExSweetSpot {
+
 
     // A Lobber Ex Sweet Spot is when a Lobber Ex collides in-between an enemy and a floor.
     // Roughly half the times, it cause the explosion to happen twice. The other half, if will only happen once.
@@ -18,7 +18,7 @@ internal class GuaranteeLobberExSweetSpot {
     [HarmonyPrefix]
     public static void StartFix(ref WeaponBouncerProjectile __instance) {
         if (Config.Settings.GuaranteeLobberExSweetSpot.Value && __instance.isEx) {
-            weaponBouncerExtraProperties.SetProperty(__instance, "ranOnCollisionGroundOther", false);
+            weaponBouncerExtraProperties.SetProperty(__instance, "ranOnCollisionGround", false);
             weaponBouncerExtraProperties.SetProperty(__instance, "alreadyRanSweetSpotFix", false);
         }
     }
@@ -27,7 +27,7 @@ internal class GuaranteeLobberExSweetSpot {
     [HarmonyPrefix]
     public static void OnCollisionGroundFix(ref WeaponBouncerProjectile __instance) {
         if (Config.Settings.GuaranteeLobberExSweetSpot.Value && __instance.isEx && !__instance.dead) {
-            weaponBouncerExtraProperties.SetProperty(__instance, "ranOnCollisionGroundOther", true);
+            weaponBouncerExtraProperties.SetProperty(__instance, "ranOnCollisionGround", true);
         }
     }
 
@@ -35,17 +35,9 @@ internal class GuaranteeLobberExSweetSpot {
     [HarmonyPrefix]
     public static void OnCollisionEnemyFix(ref WeaponBouncerProjectile __instance) {
         // Actual fix is here. If another collision type has been hit first, cause a second Lobber Ex explosion
-        if (Config.Settings.GuaranteeLobberExSweetSpot.Value && __instance.isEx && (bool)weaponBouncerExtraProperties.GetProperty(__instance, "ranOnCollisionGroundOther") && !(bool) weaponBouncerExtraProperties.GetProperty(__instance, "alreadyRanSweetSpotFix")) {
+        if (Config.Settings.GuaranteeLobberExSweetSpot.Value && __instance.isEx && (bool) weaponBouncerExtraProperties.GetProperty(__instance, "ranOnCollisionGround") && !(bool) weaponBouncerExtraProperties.GetProperty(__instance, "alreadyRanSweetSpotFix")) {
             __instance.Die();
             weaponBouncerExtraProperties.SetProperty(__instance, "alreadyRanSweetSpotFix", true);
-        }
-    }
-
-    [HarmonyPatch(typeof(WeaponBouncerProjectile), nameof(WeaponBouncerProjectile.OnCollisionOther))]
-    [HarmonyPrefix]
-    public static void OnCollisionOtherFix(ref WeaponBouncerProjectile __instance) {
-        if (Config.Settings.GuaranteeLobberExSweetSpot.Value && __instance.isEx && !__instance.dead) {
-            weaponBouncerExtraProperties.SetProperty(__instance, "ranOnCollisionGroundOther", true);
         }
     }
 

--- a/Cuphead.DebugMod/Components/HookHelper.cs
+++ b/Cuphead.DebugMod/Components/HookHelper.cs
@@ -14,7 +14,7 @@ public class HookHelper : PluginComponent {
         Actions.Add(action);
         SceneManager.activeSceneChanged += action;
     }
-    
+
     public static void ActiveSceneChanged(Action action) {
         void UnityAction(Scene _, Scene __) => action();
         Actions.Add(UnityAction);

--- a/Cuphead.DebugMod/Components/LevelSelectorEsc.cs
+++ b/Cuphead.DebugMod/Components/LevelSelectorEsc.cs
@@ -1,7 +1,7 @@
 ﻿using HarmonyLib;
 using UnityEngine;
 
-namespace BepInEx.CupheadDebugMod.Components; 
+namespace BepInEx.CupheadDebugMod.Components;
 
 [HarmonyPatch]
 public class LevelSelectorEsc : PluginComponent {

--- a/Cuphead.DebugMod/Components/RNG/BaronessPatternSelector.cs
+++ b/Cuphead.DebugMod/Components/RNG/BaronessPatternSelector.cs
@@ -1,0 +1,78 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+using BepInEx.CupheadDebugMod.Config;
+using HarmonyLib;
+using MonoMod.Cil;
+using static BepInEx.CupheadDebugMod.Config.SettingsEnums;
+using OpCodes = Mono.Cecil.Cil.OpCodes;
+
+
+namespace BepInEx.CupheadDebugMod.Components.RNG;
+
+[HarmonyPatch]
+internal class BaronessPatternSelector : PluginComponent {
+
+    [HarmonyPatch(typeof(BaronessLevel), nameof(BaronessLevel.pickminibosses_cr), MethodType.Enumerator)]
+    [HarmonyILManipulator]
+    private static void MinibossSelectionManipulator(ILContext il) {
+        ILCursor ilCursor = new(il);
+        while (ilCursor.TryGotoNext(MoveType.Before, i => i.OpCode == OpCodes.Call && i.Operand.ToString().Contains("SetUpTimeline"))) {
+            ilCursor.Index = ilCursor.Index - 2;
+            ilCursor.Emit(OpCodes.Call, typeof(BaronessPatternSelector).GetMethod(nameof(SetMinibossSelectionWrapper), BindingFlags.Static | BindingFlags.Public));
+            ilCursor.Index = ilCursor.Index + 3;
+        }
+    }
+
+    public static void SetMinibossSelectionWrapper() {
+
+        if (Level.ScoringData.difficulty == Level.Mode.Easy) {
+            int setting1 = Settings.BaronessMiniboss1Easy.Value == BaronessMinibossesEasy.Jawbreaker ? (int) Settings.BaronessMiniboss1Easy.Value + 1 : (int) Settings.BaronessMiniboss1Easy.Value;
+            int setting2 = Settings.BaronessMiniboss2Easy.Value == BaronessMinibossesEasy.Jawbreaker ? (int) Settings.BaronessMiniboss2Easy.Value + 1 : (int) Settings.BaronessMiniboss2Easy.Value;
+            int setting3 = Settings.BaronessMiniboss3Easy.Value == BaronessMinibossesEasy.Jawbreaker ? (int) Settings.BaronessMiniboss3Easy.Value + 1 : (int) Settings.BaronessMiniboss3Easy.Value;
+            SetMinibossSelection(new List<string> { "1", "2", "3", "5" }, setting1, setting2, setting3, BaronessMinibossesNormal.Random);
+
+        } else if (Level.ScoringData.difficulty == Level.Mode.Normal) {
+            SetMinibossSelection(new List<string> { "1", "2", "3", "4", "5" }, (int) Settings.BaronessMiniboss1Normal.Value, (int) Settings.BaronessMiniboss2Normal.Value, (int) Settings.BaronessMiniboss3Normal.Value, BaronessMinibossesNormal.Random);
+        } else // Hard
+          {
+            SetMinibossSelection(new List<string> { "1", "2", "3", "4", "5" }, (int) Settings.BaronessMiniboss1Hard.Value, (int) Settings.BaronessMiniboss2Hard.Value, (int) Settings.BaronessMiniboss3Hard.Value, BaronessMinibossesHard.Random);
+        }
+    }
+
+    public static void SetMinibossSelection(List<string> minibossPool, int setting1, int setting2, int setting3, object random) {
+
+        List<string> pickedMinibosses = new List<string> {
+            "0",
+            "0",
+            "0"
+        };
+
+        if (setting1 != (int) random) {
+            string minibossIndex = setting1.ToString();
+            pickedMinibosses[0] = minibossIndex;
+            minibossPool.Remove(minibossIndex);
+        }
+
+        if (setting2 != (int) random) {
+            string minibossIndex = setting2.ToString();
+            pickedMinibosses[1] = minibossIndex;
+            minibossPool.Remove(minibossIndex);
+        }
+
+        if (setting3 != (int) random) {
+            string minibossIndex = setting3.ToString();
+            pickedMinibosses[2] = minibossIndex;
+            minibossPool.Remove(minibossIndex);
+        }
+
+        for (int i = 0; i < pickedMinibosses.Count; i++) {
+            if (pickedMinibosses[i] == "0") {
+                int randIndex = UnityEngine.Random.Range(0, minibossPool.Count);
+                pickedMinibosses[i] = minibossPool[randIndex];
+                minibossPool.Remove(pickedMinibosses[i]);
+            }
+        }
+
+        BaronessLevel.PICKED_BOSSES = pickedMinibosses;
+    }
+}

--- a/Cuphead.DebugMod/Components/RNG/BeePatternSelector.cs
+++ b/Cuphead.DebugMod/Components/RNG/BeePatternSelector.cs
@@ -1,16 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using System.Reflection.Emit;
-using BepInEx.CupheadDebugMod.Config;
-using HarmonyLib;
-using UnityEngine;
-using MonoMod.Cil;
-using OpCodes = Mono.Cecil.Cil.OpCodes;
+﻿using HarmonyLib;
 using static BepInEx.CupheadDebugMod.Config.Settings;
 using static BepInEx.CupheadDebugMod.Config.SettingsEnums;
-using System.Collections;
 
 namespace BepInEx.CupheadDebugMod.Components.RNG;
 

--- a/Cuphead.DebugMod/Components/RNG/ClownPatternSelector.cs
+++ b/Cuphead.DebugMod/Components/RNG/ClownPatternSelector.cs
@@ -1,16 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using System.Reflection.Emit;
 using BepInEx.CupheadDebugMod.Config;
 using HarmonyLib;
-using UnityEngine;
 using MonoMod.Cil;
-using OpCodes = Mono.Cecil.Cil.OpCodes;
-using static BepInEx.CupheadDebugMod.Config.Settings;
 using static BepInEx.CupheadDebugMod.Config.SettingsEnums;
-using System.Collections;
+using OpCodes = Mono.Cecil.Cil.OpCodes;
 
 namespace BepInEx.CupheadDebugMod.Components.RNG;
 
@@ -31,20 +24,16 @@ internal class ClownPatternSelector : PluginComponent {
         // I am checking for Settings.ClownDashDelay.Value dynamically during this function call.
         // This is because a HarmonyTranspiler only gets called once when the script is loaded upon game bootup...
         // ...so the function call itself that gets injected into the IL code needs to check the value as it is set by Settings.ClownDashDelay.Value
-        if (Level.ScoringData.difficulty == Level.Mode.Easy)
-        {
+        if (Level.ScoringData.difficulty == Level.Mode.Easy) {
             return Settings.ClownDashDelayEasy.Value == ClownDashDelaysEasy.Random
                 ? UnityEngine.Random.Range(0, 9)
                 : (int) Settings.ClownDashDelayEasy.Value - 1;
-        }
-        else if (Level.ScoringData.difficulty == Level.Mode.Normal)
-        {
+        } else if (Level.ScoringData.difficulty == Level.Mode.Normal) {
             return Settings.ClownDashDelayNormal.Value == ClownDashDelaysNormal.Random
                 ? UnityEngine.Random.Range(0, 10)
                 : (int) Settings.ClownDashDelayNormal.Value - 1;
-        }
-        else // hard difficulty
-        {
+        } else // hard difficulty
+          {
             return Settings.ClownDashDelayHard.Value == ClownDashDelaysHard.Random
                 ? UnityEngine.Random.Range(0, 11)
                 : (int) Settings.ClownDashDelayHard.Value - 1;

--- a/Cuphead.DebugMod/Components/RNG/DevilPatternSelector.cs
+++ b/Cuphead.DebugMod/Components/RNG/DevilPatternSelector.cs
@@ -1,16 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using System.Reflection.Emit;
-using BepInEx.CupheadDebugMod.Config;
 using HarmonyLib;
-using UnityEngine;
 using MonoMod.Cil;
-using OpCodes = Mono.Cecil.Cil.OpCodes;
 using static BepInEx.CupheadDebugMod.Config.Settings;
 using static BepInEx.CupheadDebugMod.Config.SettingsEnums;
-using System.Collections;
+using OpCodes = Mono.Cecil.Cil.OpCodes;
 
 namespace BepInEx.CupheadDebugMod.Components.RNG;
 
@@ -22,16 +15,16 @@ internal class DevilPatternSelector : PluginComponent {
     [HarmonyPrefix]
 
     public static void PhaseOnePatternManipulator(ref DevilLevel __instance) {
-            if (DevilPhaseOnePattern.Value != DevilPhaseOnePatterns.Random) {
-                __instance.properties.CurrentState.patternIndex = Utility.GetUserPattern<DevilPhaseOnePatterns>((int) DevilPhaseOnePattern.Value);
-            }
+        if (DevilPhaseOnePattern.Value != DevilPhaseOnePatterns.Random) {
+            __instance.properties.CurrentState.patternIndex = Utility.GetUserPattern<DevilPhaseOnePatterns>((int) DevilPhaseOnePattern.Value);
+        }
     }
 
     [HarmonyPatch(typeof(DevilLevelSittingDevil), nameof(DevilLevelSittingDevil.LevelInit))]
     [HarmonyPostfix]
     public static void PhaseOneHeadManipulator(ref DevilLevelSittingDevil __instance) {
         if (DevilPhaseOneHeadType.Value != DevilPhaseOneHeadTypes.Random) {
-            __instance.isSpiderAttackNext = DevilPhaseOneHeadType.Value == DevilPhaseOneHeadTypes.Spider ? true : false; 
+            __instance.isSpiderAttackNext = DevilPhaseOneHeadType.Value == DevilPhaseOneHeadTypes.Spider ? true : false;
         }
     }
 
@@ -73,8 +66,9 @@ internal class DevilPatternSelector : PluginComponent {
                 // spider hop count is always between 3 and 5 on every difficulty so it can be hardcoded here for simplicity
                 UnityEngine.Random.Range(3, 6)
                 :
-                (int)DevilPhaseOneSpiderHopCount.Value + 2
-            );;
+                (int) DevilPhaseOneSpiderHopCount.Value + 2
+            );
+            ;
             ilCursor.Index++; // avoid infinite loops
         }
     }
@@ -94,8 +88,7 @@ internal class DevilPatternSelector : PluginComponent {
             if (pitchforkAttack == (int) DevilPhaseOnePitchforkType.Value + 3) {
                 if (i == 0) {
                     __instance.pitchforkPatternIndex = __instance.pitchforkPattern.Length - 1;
-                }
-                else {
+                } else {
                     __instance.pitchforkPatternIndex = i - 1;
                 }
             }
@@ -118,7 +111,7 @@ internal class DevilPatternSelector : PluginComponent {
 
     }
 
-    [HarmonyPatch(typeof(DevilLevelSittingDevil), nameof(DevilLevelSittingDevil.dragon_cr), MethodType.Enumerator)]
+    [HarmonyPatch(typeof(DevilLevelGiantHead), nameof(DevilLevelGiantHead.eye_cr), MethodType.Enumerator)]
     [HarmonyILManipulator]
     public static void PhaseTwoBombEyeDirectionManipulator(ILContext il) {
         ILCursor ilCursor = new(il);

--- a/Cuphead.DebugMod/Components/RNG/DicePalacePatternSelector.cs
+++ b/Cuphead.DebugMod/Components/RNG/DicePalacePatternSelector.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using HarmonyLib;
+using MonoMod.Cil;
+using static BepInEx.CupheadDebugMod.Config.Settings;
+using static BepInEx.CupheadDebugMod.Config.SettingsEnums;
+using OpCodes = Mono.Cecil.Cil.OpCodes;
+
+namespace BepInEx.CupheadDebugMod.Components.RNG;
+[HarmonyPatch]
+internal class DicePalacePatternSelector : PluginComponent {
+
+    [HarmonyPatch(typeof(DicePalaceMainLevelGameInfo), nameof(DicePalaceMainLevelGameInfo.ChooseHearts))]
+    [HarmonyPostfix]
+    public static void HeartsManipulator() {
+        if (DicePalaceHeartPosition1.Value != DicePalaceHeartPositions1.Random) {
+            DicePalaceMainLevelGameInfo.HEART_INDEXES[0] = (int) DicePalaceHeartPosition1.Value - 1;
+        }
+        if (DicePalaceHeartPosition2.Value != DicePalaceHeartPositions2.Random) {
+            DicePalaceMainLevelGameInfo.HEART_INDEXES[1] = (int) DicePalaceHeartPosition2.Value + 3;
+        }
+        if (DicePalaceHeartPosition3.Value != DicePalaceHeartPositions3.Random) {
+            DicePalaceMainLevelGameInfo.HEART_INDEXES[2] = (int) DicePalaceHeartPosition3.Value + 7;
+        }
+    }
+
+    [HarmonyPatch(typeof(DicePalaceCigarLevelCigar), nameof(DicePalaceCigarLevelCigar.LevelInit))]
+    [HarmonyPostfix]
+    public static void CigarAttackCountManipulator(ref DicePalaceCigarLevelCigar __instance) {
+        if (DicePalaceCigarSpitAttackCountNormal.Value != DicePalaceCigarSpitAttackCountsNormal.Random) {
+            __instance.spitAttackCountIndex = (int) DicePalaceCigarSpitAttackCountNormal.Value - 1;
+        }
+    }
+
+
+    [HarmonyPatch(typeof(DicePalaceRabbitLevel), nameof(DicePalaceRabbitLevel.Start))]
+    [HarmonyPrefix]
+    public static void RabbitPatternManipulator(ref DicePalaceRabbitLevel __instance) {
+        if (DicePalaceRabbitPattern.Value != DicePalaceRabbitPatterns.Random) {
+            __instance.properties.CurrentState.patternIndex = Utility.GetUserPattern<DicePalaceRabbitPatterns>((int) DicePalaceRabbitPattern.Value);
+        }
+    }
+
+    [HarmonyPatch(typeof(DicePalaceRabbitLevelRabbit), nameof(DicePalaceRabbitLevelRabbit.LevelInit))]
+    [HarmonyPostfix]
+    public static void RabbitParryDirectionManipulator(ref DicePalaceRabbitLevelRabbit __instance) {
+        if (DicePalaceRabbitParryDirection.Value != DicePalaceRabbitParryDirections.Random) {
+            __instance.isMagicParryTop = DicePalaceRabbitParryDirection.Value == DicePalaceRabbitParryDirections.Top;
+        }
+    }
+
+    [HarmonyPatch(typeof(DicePalaceRouletteLevel), nameof(DicePalaceRouletteLevel.Start))]
+    [HarmonyPrefix]
+    public static void RoulettePatternManipulator(ref DicePalaceRouletteLevel __instance) {
+        if (DicePalaceRoulettePattern.Value != DicePalaceRoulettePatterns.Random) {
+            __instance.properties.CurrentState.patternIndex = Utility.GetUserPattern<DicePalaceRoulettePatterns>((int) DicePalaceRoulettePattern.Value);
+        }
+    }
+
+    [HarmonyPatch(typeof(DicePalaceRouletteLevelRoulette), nameof(DicePalaceRouletteLevelRoulette.twirl_cr), MethodType.Enumerator)]
+    [HarmonyILManipulator]
+    public static void RouletteTwirlAmountsListManipulator(ILContext il) {
+        ILCursor ilCursor = new(il);
+        while (ilCursor.TryGotoNext(MoveType.Before, i => i.OpCode == OpCodes.Ldfld && i.Operand.ToString().Contains("twirlAmount"))) {
+            ilCursor.Index = ilCursor.Index - 1;
+            ilCursor.Remove();
+            ilCursor.Remove();
+            ilCursor.Remove();
+            ilCursor.Remove();
+            ilCursor.Remove();
+            ilCursor.Remove();
+            ilCursor.Remove();
+            ilCursor.Remove();
+            ilCursor.Remove();
+            ilCursor.Remove();
+            ilCursor.EmitDelegate<Func<string[], string[]>>(twirl => GetTwirlPatternList());
+            break;
+        }
+    }
+
+    static string[] GetTwirlPatternList() {
+        if (Level.ScoringData.difficulty != Level.Mode.Normal) {
+            return ["5,6,3,6,4,5,6,3,4,7,4,3"];
+        }
+
+        string[][] dicePalaceRouletteTwirlAmountsLists = [["4", "5", "3", "6", "4", "5", "4", "3", "4", "6", "4", "3"], ["5", "3", "4", "4", "3", "5", "4", "3", "6", "4", "3", "3"]];
+        if (DicePalaceRouletteTwirlAmountNormal.Value == DicePalaceRouletteTwirlAmountsNormal.Random) {
+            return dicePalaceRouletteTwirlAmountsLists[UnityEngine.Random.Range(0, 2)];
+        } else if (DicePalaceRouletteTwirlAmountNormal.Value == DicePalaceRouletteTwirlAmountsNormal.Four) {
+            return dicePalaceRouletteTwirlAmountsLists[0];
+        } else {
+            return dicePalaceRouletteTwirlAmountsLists[1];
+        }
+    }
+}

--- a/Cuphead.DebugMod/Components/RNG/FlowerPatternSelector.cs
+++ b/Cuphead.DebugMod/Components/RNG/FlowerPatternSelector.cs
@@ -1,16 +1,6 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using System.Reflection.Emit;
-using BepInEx.CupheadDebugMod.Config;
-using HarmonyLib;
-using UnityEngine;
-using MonoMod.Cil;
-using OpCodes = Mono.Cecil.Cil.OpCodes;
+﻿using HarmonyLib;
 using static BepInEx.CupheadDebugMod.Config.Settings;
 using static BepInEx.CupheadDebugMod.Config.SettingsEnums;
-using System.Collections;
-using System;
 
 namespace BepInEx.CupheadDebugMod.Components.RNG;
 

--- a/Cuphead.DebugMod/Components/RNG/FlyingBlimpPatternSelector.cs
+++ b/Cuphead.DebugMod/Components/RNG/FlyingBlimpPatternSelector.cs
@@ -1,16 +1,6 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using System.Reflection.Emit;
-using BepInEx.CupheadDebugMod.Config;
-using HarmonyLib;
-using UnityEngine;
-using MonoMod.Cil;
-using OpCodes = Mono.Cecil.Cil.OpCodes;
+﻿using HarmonyLib;
 using static BepInEx.CupheadDebugMod.Config.Settings;
 using static BepInEx.CupheadDebugMod.Config.SettingsEnums;
-using System.Collections;
-using System;
 
 namespace BepInEx.CupheadDebugMod.Components.RNG;
 
@@ -28,35 +18,27 @@ public class FlyingBlimpPatternSelector : PluginComponent {
                 if (FlyingBlimpPhaseBlimp2PatternEasy.Value != FlyingBlimpPhaseBlimp2PatternsEasy.Random) {
                     __instance.properties.CurrentState.patternIndex = Utility.GetUserPattern<FlyingBlimpPhaseBlimp2PatternsEasy>((int) FlyingBlimpPhaseBlimp2PatternEasy.Value);
                 }
-            }
-            else if (IsWithinPhase(0.23f, 0.00f, __instance)) {
+            } else if (IsWithinPhase(0.23f, 0.00f, __instance)) {
                 if (FlyingBlimpPhaseBlimp3PatternNormal.Value != FlyingBlimpPhaseBlimp3PatternsNormal.Random) {
                     __instance.properties.CurrentState.patternIndex = Utility.GetUserPattern<FlyingBlimpPhaseBlimp3PatternsNormal>((int) FlyingBlimpPhaseBlimp3PatternNormal.Value);
                 }
             }
-        }
-
-        else if (Level.ScoringData.difficulty == Level.Mode.Normal) {
-            if (IsWithinPhase(0.77f, 0.64f, __instance))
-            {
+        } else if (Level.ScoringData.difficulty == Level.Mode.Normal) {
+            if (IsWithinPhase(0.77f, 0.64f, __instance)) {
                 if (FlyingBlimpPhaseBlimp2PatternNormal.Value != FlyingBlimpPhaseBlimp2PatternsNormal.Random) {
                     __instance.properties.CurrentState.patternIndex = Utility.GetUserPattern<FlyingBlimpPhaseBlimp2PatternsNormal>((int) FlyingBlimpPhaseBlimp2PatternNormal.Value);
                 }
-            }
-            else if (IsWithinPhase(0.46f, 0.34f, __instance)) {
+            } else if (IsWithinPhase(0.46f, 0.34f, __instance)) {
                 if (FlyingBlimpPhaseBlimp3PatternNormal.Value != FlyingBlimpPhaseBlimp3PatternsNormal.Random) {
                     __instance.properties.CurrentState.patternIndex = Utility.GetUserPattern<FlyingBlimpPhaseBlimp3PatternsNormal>((int) FlyingBlimpPhaseBlimp3PatternNormal.Value);
                 }
             }
-        }
-
-        else if (Level.ScoringData.difficulty == Level.Mode.Hard) {
+        } else if (Level.ScoringData.difficulty == Level.Mode.Hard) {
             if (IsWithinPhase(0.8f, 0.67f, __instance)) {
                 if (FlyingBlimpPhaseBlimp2PatternHard.Value != FlyingBlimpPhaseBlimp2PatternsHard.Random) {
                     __instance.properties.CurrentState.patternIndex = Utility.GetUserPattern<FlyingBlimpPhaseBlimp2PatternsHard>((int) FlyingBlimpPhaseBlimp2PatternHard.Value);
                 }
-            }
-            else if (IsWithinPhase(0.51f, 0.39f, __instance)) {
+            } else if (IsWithinPhase(0.51f, 0.39f, __instance)) {
                 if (FlyingBlimpPhaseBlimp3PatternHard.Value != FlyingBlimpPhaseBlimp3PatternsHard.Random) {
                     __instance.properties.CurrentState.patternIndex = Utility.GetUserPattern<FlyingBlimpPhaseBlimp3PatternsHard>((int) FlyingBlimpPhaseBlimp3PatternHard.Value);
                 }
@@ -64,8 +46,7 @@ public class FlyingBlimpPatternSelector : PluginComponent {
         }
     }
 
-    protected static bool IsWithinPhase(float phaseStart, float phaseEnd, FlyingBlimpLevel __instance)
-    {
+    protected static bool IsWithinPhase(float phaseStart, float phaseEnd, FlyingBlimpLevel __instance) {
         // i'm not actually sure on the inclusivity of values here ( <, > vs <=, >=). i'm taking a guess.
         return (__instance.properties.CurrentState.stateName == LevelProperties.FlyingBlimp.States.Generic &&
         (Level.Current.timeline.health - Level.Current.timeline.damage) / Level.Current.timeline.health <= phaseStart &&

--- a/Cuphead.DebugMod/Components/RNG/FlyingGeniePatternSelector.cs
+++ b/Cuphead.DebugMod/Components/RNG/FlyingGeniePatternSelector.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection.Emit;
-using System.Text;
 using HarmonyLib;
 using MonoMod.Cil;
 using static BepInEx.CupheadDebugMod.Config.Settings;

--- a/Cuphead.DebugMod/Components/RNG/FlyingMermaidPatternSelector.cs
+++ b/Cuphead.DebugMod/Components/RNG/FlyingMermaidPatternSelector.cs
@@ -1,16 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using System.Reflection.Emit;
-using BepInEx.CupheadDebugMod.Config;
-using HarmonyLib;
-using UnityEngine;
-using MonoMod.Cil;
-using OpCodes = Mono.Cecil.Cil.OpCodes;
+﻿using HarmonyLib;
 using static BepInEx.CupheadDebugMod.Config.Settings;
 using static BepInEx.CupheadDebugMod.Config.SettingsEnums;
-using System.Collections;
 
 namespace BepInEx.CupheadDebugMod.Components.RNG;
 
@@ -27,8 +17,7 @@ internal class FlyingMermaidPatternSelector : PluginComponent {
             if (FlyingMermaidPhaseOneFirstPatternEasy.Value != FlyingMermaidPhaseOneFirstPatternsEasy.Random) {
                 __instance.properties.CurrentState.patternIndex = Utility.GetUserPattern<FlyingMermaidPhaseOneFirstPatternsEasy>((int) FlyingMermaidPhaseOneFirstPatternEasy.Value);
             }
-        }
-        else {
+        } else {
             if (FlyingMermaidPhaseOnePatternNormalHard.Value != FlyingMermaidPhaseOnePatternsNormalHard.Random) {
                 // little trick i'm doing behind the scenes here
                 // normal and hard mode don't QUITE have the same patterns list. their lists are ordered the same in the end, but the starting point is different
@@ -69,7 +58,7 @@ internal class FlyingMermaidPatternSelector : PluginComponent {
             __instance.fishPattern = array;
             __instance.fishIndex = Utility.GetUserPattern<FlyingMermaidPhaseOneFishPatterns>((int) FlyingMermaidPhaseOneFishPattern.Value);
         }
-            
+
     }
 
     [HarmonyPatch(typeof(FlyingMermaidLevelMermaid), nameof(FlyingMermaidLevelMermaid.LevelInit))]

--- a/Cuphead.DebugMod/Components/RNG/FrogsPatternSelector.cs
+++ b/Cuphead.DebugMod/Components/RNG/FrogsPatternSelector.cs
@@ -1,15 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using System.Reflection.Emit;
 using BepInEx.CupheadDebugMod.Config;
 using HarmonyLib;
-using UnityEngine;
 using MonoMod.Cil;
-using OpCodes = Mono.Cecil.Cil.OpCodes;
 using static BepInEx.CupheadDebugMod.Config.SettingsEnums;
-using System.Collections;
+using OpCodes = Mono.Cecil.Cil.OpCodes;
 
 namespace BepInEx.CupheadDebugMod.Components.RNG;
 
@@ -47,4 +41,64 @@ public class FrogsPatternSelector : PluginComponent {
             ilCursor.Index++; // avoid infinite loops
         }
     }
+
+
+    [HarmonyPatch(typeof(FrogsLevelTall), nameof(FrogsLevelTall.fireflies_cr), MethodType.Enumerator)]
+    [HarmonyILManipulator]
+    private static void PhaseOneFirefliesPatternForcer(ILContext il) {
+        ILCursor ilCursor = new(il);
+        while (ilCursor.TryGotoNext(MoveType.Before, i => i.OpCode == OpCodes.Stfld && i.Operand.ToString().Contains("<patternString>"))) {
+            ilCursor.EmitDelegate<Func<string, string>>(x => GetFirefliesPattern());
+            ilCursor.Index++; // avoid infinite loops
+        }
+    }
+
+    private static string GetFirefliesPattern() {
+        // I am checking for Settings.ClownDashDelay.Value dynamically during this function call.
+        // This is because a HarmonyTranspiler only gets called once when the script is loaded upon game bootup...
+        // ...so the function call itself that gets injected into the IL code needs to check the value as it is set by Settings.ClownDashDelay.Value
+        if (Level.ScoringData.difficulty == Level.Mode.Easy) {
+            return Settings.FrogsPhaseOneFirefliesPatternEasy.Value == FrogsPhaseOneFirefliesPatternsEasy.Random
+                ? firefliesPatternStringsEasy[UnityEngine.Random.Range(0, 3)]
+                : firefliesPatternStringsEasy[(int) Settings.FrogsPhaseOneFirefliesPatternEasy.Value - 1];
+        } else if (Level.ScoringData.difficulty == Level.Mode.Normal) {
+            return Settings.FrogsPhaseOneFirefliesPatternNormal.Value == FrogsPhaseOneFirefliesPatternsNormal.Random
+                ? firefliesPatternStringsNormal[UnityEngine.Random.Range(0, 4)]
+                : firefliesPatternStringsNormal[(int) Settings.FrogsPhaseOneFirefliesPatternNormal.Value - 1];
+        } else // hard difficulty
+          {
+            return Settings.FrogsPhaseOneFirefliesPatternHard.Value == FrogsPhaseOneFirefliesPatternsHard.Random
+                ? firefliesPatternStringsHard[UnityEngine.Random.Range(0, 7)]
+                : firefliesPatternStringsHard[(int) Settings.FrogsPhaseOneFirefliesPatternHard.Value - 1];
+        }
+
+    }
+
+
+    readonly static string[] firefliesPatternStringsEasy = {
+        "D:1, S:2, D:1.5, S:1, D:1, S:1",
+        "D:1.5, S:1, D:1.5, S:1, D:1, S:2",
+        "D:0.5, S:2, D:1, S:1, D:0.5, S:1"
+    };
+
+    readonly static string[] firefliesPatternStringsNormal = {
+        "D:1, S:2, D:1, S:2, D:1, S:1, D:1, S:2",
+        "D:1, S:2, D:1, S:2, D:1, S:2",
+        "D:1, S:2, D:1, S:1, D:1, S:2, D:1, S:2",
+        "D:1, S:2, D:1, S:2, D:1, S:1"
+    };
+
+    readonly static string[] firefliesPatternStringsHard = {
+        "D:1, S:2, D:2.5, S:2, D:1.5, S:1",
+        "D:0.5, S:1, D:2, S:1, D:1.5, S:2",
+        "D:1, S:2, D:2.2, S:2",
+        "D:1, S:2, D:2, S:1, D:1, S:1",
+        "D:0.5, S:1, D:2.5, S:2, D:2.1, S:2",
+        "D:1.4, S:2, D:2.4, S:2",
+        "D:1, S:1, D:1.8, S:2, D:1.5, S:1"
+    };
+
+
+
+
 }

--- a/Cuphead.DebugMod/Components/RNG/MousePatternSelector.cs
+++ b/Cuphead.DebugMod/Components/RNG/MousePatternSelector.cs
@@ -1,13 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using BepInEx.CupheadDebugMod.Config;
+﻿using HarmonyLib;
 using static BepInEx.CupheadDebugMod.Config.Settings;
 using static BepInEx.CupheadDebugMod.Config.SettingsEnums;
-using OpCodes = Mono.Cecil.Cil.OpCodes;
-using HarmonyLib;
-using MonoMod.Cil;
 
 namespace BepInEx.CupheadDebugMod.Components.RNG;
 

--- a/Cuphead.DebugMod/Components/RNG/PiratePatternSelector.cs
+++ b/Cuphead.DebugMod/Components/RNG/PiratePatternSelector.cs
@@ -1,0 +1,254 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+using HarmonyLib;
+using MonoMod.Cil;
+using static BepInEx.CupheadDebugMod.Config.Settings;
+using static BepInEx.CupheadDebugMod.Config.SettingsEnums;
+using OpCodes = Mono.Cecil.Cil.OpCodes;
+
+namespace BepInEx.CupheadDebugMod.Components.RNG;
+
+[HarmonyPatch]
+public class PiratePatternSelector : PluginComponent {
+
+    [HarmonyPatch(typeof(PirateLevel), nameof(PirateLevel.peashot_cr), MethodType.Enumerator)]
+    [HarmonyILManipulator]
+    public static void GunManipulator(ILContext il) {
+        ILCursor ilCursor = new(il);
+        while (ilCursor.TryGotoNext(MoveType.Before, i => i.OpCode == OpCodes.Call && i.Operand.ToString().Contains("UnityEngine.Random"))) {
+            ilCursor.Index = ilCursor.Index - 6;
+            ilCursor.Remove();
+            ilCursor.Remove();
+            ilCursor.Remove();
+            ilCursor.Remove();
+            ilCursor.Remove();
+            ilCursor.Remove();
+            ilCursor.Remove();
+            ilCursor.Emit(OpCodes.Call, typeof(PiratePatternSelector).GetMethod(nameof(SetGunPattern), BindingFlags.Static | BindingFlags.Public));
+            break;
+        }
+    }
+
+    [HarmonyPatch(typeof(PirateLevel), nameof(PirateLevel.OnStateChanged))]
+    [HarmonyPrefix]
+    public static void SubsequentPhasesPatternManipulator(ref PirateLevel __instance) {
+        if (Level.ScoringData.difficulty == Level.Mode.Easy) {
+            if (IsWithinPhase(0.68f, 0.52f)) {
+                if (PiratePhaseFourPatternEasy.Value != PiratePhaseFourPatternsEasy.Random) {
+                    __instance.properties.CurrentState.patternIndex = Utility.GetUserPattern<PiratePhaseFourPatternsEasy>((int) PiratePhaseFourPatternEasy.Value);
+                }
+            }
+            if (IsWithinPhase(0.22f, 0.0f)) {
+                if (PiratePhaseSevenPatternEasy.Value != PiratePhaseSevenPatternsEasy.Random) {
+                    __instance.properties.CurrentState.patternIndex = Utility.GetUserPattern<PiratePhaseSevenPatternsEasy>((int) PiratePhaseSevenPatternEasy.Value);
+                }
+            }
+        }
+
+        if (Level.ScoringData.difficulty == Level.Mode.Normal) {
+            if (IsWithinPhase(0.87f, 0.51f)) {
+                if (PiratePhaseTwoPatternNormalHard.Value != PiratePhaseTwoPatternsNormalHard.Random) {
+                    var firstPattern = __instance.properties.CurrentState.patterns[0];
+                    if (firstPattern == LevelProperties.Pirate.Pattern.Peashot) {
+                        __instance.properties.CurrentState.patternIndex = Utility.GetUserPattern<PiratePhaseTwoPatternsNormalHard>(PhaseTwoPatternsNormal1[PiratePhaseTwoPatternNormalHard.Value]);
+                    } else {
+                        __instance.properties.CurrentState.patternIndex = Utility.GetUserPattern<PiratePhaseTwoPatternsNormalHard>(PhaseTwoPatternsNormal2[PiratePhaseTwoPatternNormalHard.Value]);
+                    }
+                }
+            }
+            if (IsWithinPhase(0.51f, 0.22f)) {
+                if (PiratePhaseThreePatternNormalHard.Value != PiratePhaseThreePatternsNormalHard.Random) {
+                    var firstPattern = __instance.properties.CurrentState.patterns[0];
+                    if (firstPattern == LevelProperties.Pirate.Pattern.Peashot) {
+                        __instance.properties.CurrentState.patternIndex = Utility.GetUserPattern<PiratePhaseThreePatternsNormalHard>(PhaseThreePatternsNormal1[PiratePhaseThreePatternNormalHard.Value]);
+                    } else {
+                        __instance.properties.CurrentState.patternIndex = Utility.GetUserPattern<PiratePhaseThreePatternsNormalHard>(PhaseThreePatternsNormal2[PiratePhaseThreePatternNormalHard.Value]);
+                    }
+                }
+            }
+        }
+
+        if (Level.ScoringData.difficulty == Level.Mode.Hard) {
+            if (IsWithinPhase(0.92f, 0.77f)) {
+                if (PiratePhaseTwoPatternNormalHard.Value != PiratePhaseTwoPatternsNormalHard.Random) {
+                    var firstPattern = __instance.properties.CurrentState.patterns[0];
+                    if (firstPattern == LevelProperties.Pirate.Pattern.Peashot) {
+                        __instance.properties.CurrentState.patternIndex = Utility.GetUserPattern<PiratePhaseTwoPatternsNormalHard>(PhaseTwoPatternsHard1[PiratePhaseTwoPatternNormalHard.Value]);
+                    } else {
+                        __instance.properties.CurrentState.patternIndex = Utility.GetUserPattern<PiratePhaseTwoPatternsNormalHard>(PhaseTwoPatternsHard2[PiratePhaseTwoPatternNormalHard.Value]);
+                    }
+                }
+            }
+            if (IsWithinPhase(0.77f, 0.32f)) {
+                if (PiratePhaseThreePatternNormalHard.Value != PiratePhaseThreePatternsNormalHard.Random) {
+                    var firstPattern = __instance.properties.CurrentState.patterns[0];
+                    if (firstPattern == LevelProperties.Pirate.Pattern.Peashot) {
+                        __instance.properties.CurrentState.patternIndex = Utility.GetUserPattern<PiratePhaseThreePatternsNormalHard>(PhaseThreePatternsHard1[PiratePhaseThreePatternNormalHard.Value]);
+                    } else {
+                        __instance.properties.CurrentState.patternIndex = Utility.GetUserPattern<PiratePhaseThreePatternsNormalHard>(PhaseThreePatternsHard2[PiratePhaseThreePatternNormalHard.Value]);
+                    }
+                }
+            }
+        }
+    }
+
+    public static int SetGunPattern() {
+        if (Level.ScoringData.difficulty == Level.Mode.Easy) {
+            if (IsWithinPhase(0.82f, 0.68f)) {
+                if (PiratePhaseThreeGunPatternEasy.Value != PiratePhaseThreeGunPatternsEasy.Random) {
+                    return (int) PiratePhaseThreeGunPatternEasy.Value - 1;
+                }
+            }
+            if (IsWithinPhase(0.68f, 0.52f)) {
+                if (PiratePhaseFourGunPatternEasy.Value != PiratePhaseFourGunPatternsEasy.Random) {
+                    return (int) PiratePhaseFourGunPatternEasy.Value - 1;
+                }
+            }
+            if (IsWithinPhase(0.22f, 0.0f)) {
+                if (PiratePhaseSevenGunPatternEasy.Value != PiratePhaseSevenGunPatternsEasy.Random) {
+                    return PhaseSevenGunPatternsEasy[PiratePhaseSevenGunPatternEasy.Value];
+                }
+            }
+        }
+
+
+        if (Level.ScoringData.difficulty == Level.Mode.Normal) {
+            if (IsWithinPhase(1.0f, 0.87f)) {
+                if (PiratePhaseOneGunPatternNormal.Value != PiratePhaseOneGunPatternsNormal.Random) {
+                    return (int) PiratePhaseOneGunPatternNormal.Value - 1;
+                }
+            }
+            if (IsWithinPhase(0.87f, 0.51f)) {
+                if (PiratePhaseTwoGunPatternNormal.Value != PiratePhaseTwoGunPatternsNormal.Random) {
+                    return (int) PiratePhaseTwoGunPatternNormal.Value - 1;
+                }
+            }
+            if (IsWithinPhase(0.51f, 0.22f)) {
+                if (PiratePhaseThreeGunPatternNormal.Value != PiratePhaseThreeGunPatternsNormal.Random) {
+                    return (int) PiratePhaseThreeGunPatternNormal.Value - 1;
+                }
+            }
+        }
+
+        if (Level.ScoringData.difficulty == Level.Mode.Hard) {
+            if (IsWithinPhase(1.0f, 0.92f)) {
+                if (PiratePhaseOneGunPatternHard.Value != PiratePhaseOneGunPatternsHard.Random) {
+                    return (int) PiratePhaseOneGunPatternHard.Value - 1;
+                }
+            }
+            if (IsWithinPhase(0.92f, 0.77f)) {
+                if (PiratePhaseTwoGunPatternHard.Value != PiratePhaseTwoGunPatternsHard.Random) {
+                    return (int) PiratePhaseTwoGunPatternHard.Value - 1;
+                }
+            }
+            if (IsWithinPhase(0.77f, 0.32f)) {
+                if (PiratePhaseThreeGunPatternHard.Value != PiratePhaseThreeGunPatternsHard.Random) {
+                    return PhaseThreeGunPatternsHard[PiratePhaseThreeGunPatternHard.Value];
+                }
+            }
+        }
+
+        PirateLevel pirateLevelInstance = FindObjectOfType<PirateLevel>();
+        return UnityEngine.Random.Range(0, pirateLevelInstance.properties.CurrentState.peashot.patterns.Length);
+
+
+    }
+
+    protected static bool IsWithinPhase(float phaseStart, float phaseEnd) {
+        return
+        (Level.Current.timeline.health - Level.Current.timeline.damage) / Level.Current.timeline.health <= phaseStart &&
+        (Level.Current.timeline.health - Level.Current.timeline.damage) / Level.Current.timeline.health > phaseEnd;
+    }
+
+    public static readonly Dictionary<PiratePhaseTwoPatternsNormalHard, int> PhaseTwoPatternsNormal1 = new Dictionary<PiratePhaseTwoPatternsNormalHard, int> {
+        { PiratePhaseTwoPatternsNormalHard.PeashotShark, 1 },
+        { PiratePhaseTwoPatternsNormalHard.Shark, 2 },
+        { PiratePhaseTwoPatternsNormalHard.PeashotSquid, 3 },
+        { PiratePhaseTwoPatternsNormalHard.Squid, 4 },
+        { PiratePhaseTwoPatternsNormalHard.PeashotDogfish, 5 },
+        { PiratePhaseTwoPatternsNormalHard.Dogfish, 6 }
+    };
+
+    public static readonly Dictionary<PiratePhaseTwoPatternsNormalHard, int> PhaseTwoPatternsNormal2 = new Dictionary<PiratePhaseTwoPatternsNormalHard, int> {
+        { PiratePhaseTwoPatternsNormalHard.PeashotShark, 2 },
+        { PiratePhaseTwoPatternsNormalHard.Shark, 3 },
+        { PiratePhaseTwoPatternsNormalHard.PeashotSquid, 6 },
+        { PiratePhaseTwoPatternsNormalHard.Squid, 1 },
+        { PiratePhaseTwoPatternsNormalHard.PeashotDogfish, 4 },
+        { PiratePhaseTwoPatternsNormalHard.Dogfish, 5 }
+    };
+
+    public static readonly Dictionary<PiratePhaseTwoPatternsNormalHard, int> PhaseTwoPatternsHard1 = new Dictionary<PiratePhaseTwoPatternsNormalHard, int> {
+        { PiratePhaseTwoPatternsNormalHard.PeashotShark, 3 },
+        { PiratePhaseTwoPatternsNormalHard.Shark, 4 },
+        { PiratePhaseTwoPatternsNormalHard.PeashotSquid, 1 },
+        { PiratePhaseTwoPatternsNormalHard.Squid, 2 },
+        { PiratePhaseTwoPatternsNormalHard.PeashotDogfish, 5 },
+        { PiratePhaseTwoPatternsNormalHard.Dogfish, 6 }
+    };
+
+    public static readonly Dictionary<PiratePhaseTwoPatternsNormalHard, int> PhaseTwoPatternsHard2 = new Dictionary<PiratePhaseTwoPatternsNormalHard, int> {
+        { PiratePhaseTwoPatternsNormalHard.PeashotShark, 6 },
+        { PiratePhaseTwoPatternsNormalHard.Shark, 1 },
+        { PiratePhaseTwoPatternsNormalHard.PeashotSquid, 2 },
+        { PiratePhaseTwoPatternsNormalHard.Squid, 3 },
+        { PiratePhaseTwoPatternsNormalHard.PeashotDogfish, 4 },
+        { PiratePhaseTwoPatternsNormalHard.Dogfish, 5 }
+    };
+
+
+    public static readonly Dictionary<PiratePhaseThreePatternsNormalHard, int> PhaseThreePatternsNormal1 = new Dictionary<PiratePhaseThreePatternsNormalHard, int> {
+        { PiratePhaseThreePatternsNormalHard.PeashotShark, 1 },
+        { PiratePhaseThreePatternsNormalHard.Shark, 2 },
+        { PiratePhaseThreePatternsNormalHard.PeashotSquid, 3 },
+        { PiratePhaseThreePatternsNormalHard.Squid, 4 },
+        { PiratePhaseThreePatternsNormalHard.PeashotDogfish, 5 },
+        { PiratePhaseThreePatternsNormalHard.Dogfish, 6 }
+    };
+
+    public static readonly Dictionary<PiratePhaseThreePatternsNormalHard, int> PhaseThreePatternsNormal2 = new Dictionary<PiratePhaseThreePatternsNormalHard, int> {
+        { PiratePhaseThreePatternsNormalHard.PeashotShark, 4 },
+        { PiratePhaseThreePatternsNormalHard.Shark, 5 },
+        { PiratePhaseThreePatternsNormalHard.PeashotSquid, 2 },
+        { PiratePhaseThreePatternsNormalHard.Squid, 3 },
+        { PiratePhaseThreePatternsNormalHard.PeashotDogfish, 6 },
+        { PiratePhaseThreePatternsNormalHard.Dogfish, 1 }
+    };
+
+    public static readonly Dictionary<PiratePhaseThreePatternsNormalHard, int> PhaseThreePatternsHard1 = new Dictionary<PiratePhaseThreePatternsNormalHard, int> {
+        { PiratePhaseThreePatternsNormalHard.PeashotShark, 3 },
+        { PiratePhaseThreePatternsNormalHard.Shark, 4 },
+        { PiratePhaseThreePatternsNormalHard.PeashotSquid, 1 },
+        { PiratePhaseThreePatternsNormalHard.Squid, 2 },
+        { PiratePhaseThreePatternsNormalHard.PeashotDogfish, 5 },
+        { PiratePhaseThreePatternsNormalHard.Dogfish, 6 }
+    };
+
+    public static readonly Dictionary<PiratePhaseThreePatternsNormalHard, int> PhaseThreePatternsHard2 = new Dictionary<PiratePhaseThreePatternsNormalHard, int> {
+        { PiratePhaseThreePatternsNormalHard.PeashotShark, 6 },
+        { PiratePhaseThreePatternsNormalHard.Shark, 1 },
+        { PiratePhaseThreePatternsNormalHard.PeashotSquid, 2 },
+        { PiratePhaseThreePatternsNormalHard.Squid, 3 },
+        { PiratePhaseThreePatternsNormalHard.PeashotDogfish, 4 },
+        { PiratePhaseThreePatternsNormalHard.Dogfish, 5 }
+    };
+
+
+    public static readonly Dictionary<PiratePhaseSevenGunPatternsEasy, int> PhaseSevenGunPatternsEasy = new Dictionary<PiratePhaseSevenGunPatternsEasy, int> {
+        { PiratePhaseSevenGunPatternsEasy.Two_One_Two_1, 1 },
+        { PiratePhaseSevenGunPatternsEasy.Two_Two_One, 2 },
+        { PiratePhaseSevenGunPatternsEasy.Three, 3 },
+        { PiratePhaseSevenGunPatternsEasy.One_Two_Two, 4 },
+        { PiratePhaseSevenGunPatternsEasy.One_Three, 5 },
+        { PiratePhaseSevenGunPatternsEasy.Two_One_Two_2, 7 },
+        { PiratePhaseSevenGunPatternsEasy.Four, 8 }
+    };
+
+    public static readonly Dictionary<PiratePhaseThreeGunPatternsHard, int> PhaseThreeGunPatternsHard = new Dictionary<PiratePhaseThreeGunPatternsHard, int> {
+        { PiratePhaseThreeGunPatternsHard.Two, 1 },
+        { PiratePhaseThreeGunPatternsHard.Three, 4 },
+        { PiratePhaseThreeGunPatternsHard.Four, 3 }
+    };
+
+
+}

--- a/Cuphead.DebugMod/Components/RNG/RobotPatternSelector.cs
+++ b/Cuphead.DebugMod/Components/RNG/RobotPatternSelector.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using BepInEx.CupheadDebugMod.Config;
+using HarmonyLib;
+using MonoMod.Cil;
+using static BepInEx.CupheadDebugMod.Config.SettingsEnums;
+using OpCodes = Mono.Cecil.Cil.OpCodes;
+
+
+namespace BepInEx.CupheadDebugMod.Components.RNG;
+
+[HarmonyPatch]
+public class RobotPatternSelector : PluginComponent {
+    [HarmonyPatch(typeof(RobotLevelHelihead), nameof(RobotLevelHelihead.InitHeliHead))]
+    [HarmonyILManipulator]
+    public static void PhaseFinalGemManipulator(ILContext il) {
+        ILCursor ilCursor = new(il);
+        while (ilCursor.TryGotoNext(MoveType.Before, i => i.OpCode == OpCodes.Stfld && i.Operand.ToString().Contains("attackTypeIndex"))) {
+            ilCursor.EmitDelegate<Func<int, int>>(gemColor =>
+                Settings.RobotPhaseFinalGemColor.Value == RobotPhaseFinalGemColors.Random
+                ? UnityEngine.Random.Range(0, 2)
+                : (int) Settings.RobotPhaseFinalGemColor.Value - 1
+            );
+            ilCursor.Index++;
+        }
+    }
+
+}

--- a/Cuphead.DebugMod/Components/RNG/TrainPatternSelector.cs
+++ b/Cuphead.DebugMod/Components/RNG/TrainPatternSelector.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using HarmonyLib;
+using MonoMod.Cil;
+using static BepInEx.CupheadDebugMod.Config.Settings;
+using static BepInEx.CupheadDebugMod.Config.SettingsEnums;
+using OpCodes = Mono.Cecil.Cil.OpCodes;
+
+namespace BepInEx.CupheadDebugMod.Components.RNG;
+
+[HarmonyPatch]
+public class TrainPatternSelector : PluginComponent {
+
+    [HarmonyPatch(typeof(TrainLevel), nameof(TrainLevel.pumpkins_cr), MethodType.Enumerator)]
+    [HarmonyILManipulator]
+    public static void PumpkinManipulator(ILContext il) {
+        ILCursor ilCursor = new(il);
+        while (ilCursor.TryGotoNext(MoveType.Before, i => i.OpCode == OpCodes.Stfld && i.Operand.ToString().Contains("<dir>__0"))) {
+            ilCursor.Index = ilCursor.Index - 4;
+            ilCursor.Remove();
+            ilCursor.Remove();
+            ilCursor.Remove();
+            ilCursor.Remove();
+
+            ilCursor.EmitDelegate<Func<bool, int>>(dir =>
+            TrainPumpkinStartingDirection.Value == TrainPumpkinStartingDirections.Random ?
+            (!Rand.Bool()) ? -1 : 1
+            :
+            TrainPumpkinStartingDirection.Value == TrainPumpkinStartingDirections.Right ? -1 : 1
+            );
+            break;
+        }
+    }
+
+    [HarmonyPatch(typeof(TrainLevelLollipopGhoulsManager), nameof(TrainLevelLollipopGhoulsManager.ghouls_cr), MethodType.Enumerator)]
+    [HarmonyILManipulator]
+    public static void GhoulManipulator(ILContext il) {
+        ILCursor ilCursor = new(il);
+        while (ilCursor.TryGotoNext(MoveType.Before, i => i.OpCode == OpCodes.Stfld && i.Operand.ToString().Contains("current"))) {
+            ilCursor.EmitDelegate<Func<bool, int>>(twin =>
+            TrainStartingGhoul.Value == TrainStartingGhouls.Random ?
+            UnityEngine.Random.Range(0, 2)
+            :
+            TrainStartingGhoul.Value == TrainStartingGhouls.Right ? 0 : 1
+            );
+            break;
+        }
+    }
+}

--- a/Cuphead.DebugMod/Components/RNG/Utility.cs
+++ b/Cuphead.DebugMod/Components/RNG/Utility.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using BepInEx.Configuration;
 
 namespace BepInEx.CupheadDebugMod.Components.RNG {
     internal class Utility {

--- a/Cuphead.DebugMod/Config/ConfigurationManagerAttributes.cs
+++ b/Cuphead.DebugMod/Config/ConfigurationManagerAttributes.cs
@@ -30,8 +30,7 @@ using BepInEx.Configuration;
 /// You can optionally remove fields that you won't use from this class, it's the same as leaving them null.
 /// </remarks>
 #pragma warning disable 0169, 0414, 0649
-internal sealed class ConfigurationManagerAttributes
-{
+internal sealed class ConfigurationManagerAttributes {
     /// <summary>
     /// Should the setting be shown as a percentage (only use with value range settings).
     /// </summary>

--- a/Cuphead.DebugMod/Config/Settings.cs
+++ b/Cuphead.DebugMod/Config/Settings.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using BepInEx.Configuration;
-using BepInEx.CupheadDebugMod.Components;
 using UnityEngine;
 using static BepInEx.CupheadDebugMod.Config.SettingsEnums;
 
@@ -29,7 +28,6 @@ public class Settings : PluginComponent {
     public static ConfigEntry<KeyboardShortcut> ClearCharmsSupers;
     public static ConfigEntry<KeyboardShortcut> QuickRestart;
 
-    public static ConfigEntry<KeyboardShortcut> ToggleAllPanels;
     public static ConfigEntry<KeyboardShortcut> ToggleBetweenPanels;
 
     public static ConfigEntry<KeyboardShortcut> CameraZoomIn;
@@ -37,18 +35,35 @@ public class Settings : PluginComponent {
     public static ConfigEntry<KeyboardShortcut> CameraZoomReset;
 
     public static ConfigEntry<bool> AllowRecollectCoins;
-    
+
     public static ConfigEntry<KeyboardShortcut> DecreaseSpeed;
     public static ConfigEntry<KeyboardShortcut> IncreaseSpeed;
     public static ConfigEntry<KeyboardShortcut> ResetSpeed;
     public static ConfigEntry<KeyboardShortcut> PauseResume;
     public static ConfigEntry<KeyboardShortcut> FrameAdvance;
 
-    #if v1_3
+    public static ConfigEntry<bool> RTATime;
+    public static ConfigEntry<bool> IGTTime;
+    public static ConfigEntry<bool> Goal;
+    public static ConfigEntry<bool> Parries;
+    public static ConfigEntry<bool> Supers;
+    public static ConfigEntry<bool> Damage;
+    public static ConfigEntry<bool> CurrentRank;
+    public static ConfigEntry<bool> Difficulty;
+    public static ConfigEntry<bool> DmgMultiplier;
+    public static ConfigEntry<bool> PlayerCount;
+    public static ConfigEntry<bool> CurrentScene;
+    public static ConfigEntry<bool> WeaponCooldowns;
+    public static ConfigEntry<bool> OnEXWeaponCooldown;
+
+#if v1_3
     public static ConfigEntry<RelicLevels> RelicLevel;
-    #endif
+#endif
 
     public static ConfigEntry<FrogsPhaseOnePatterns> FrogsPhaseOnePattern;
+    public static ConfigEntry<FrogsPhaseOneFirefliesPatternsEasy> FrogsPhaseOneFirefliesPatternEasy;
+    public static ConfigEntry<FrogsPhaseOneFirefliesPatternsNormal> FrogsPhaseOneFirefliesPatternNormal;
+    public static ConfigEntry<FrogsPhaseOneFirefliesPatternsHard> FrogsPhaseOneFirefliesPatternHard;
     public static ConfigEntry<FrogsPhaseFinalPatterns> FrogsPhaseFinalPattern;
     public static ConfigEntry<FlyingBlimpPhaseBlimp2PatternsEasy> FlyingBlimpPhaseBlimp2PatternEasy;
     public static ConfigEntry<FlyingBlimpPhaseBlimp3PatternsEasy> FlyingBlimpPhaseBlimp3PatternEasy;
@@ -60,6 +75,21 @@ public class Settings : PluginComponent {
     public static ConfigEntry<FlowerPhaseGeneric2PatternsNormal> FlowerPhaseGeneric2PatternNormal;
     public static ConfigEntry<FlowerPhaseGeneric3PatternsNormal> FlowerPhaseGeneric3PatternNormal;
     public static ConfigEntry<FlowerPhaseGenericHeadLungePatternsNormal> FlowerPhaseGenericHeadLungePatternNormal;
+    public static ConfigEntry<BaronessMinibossesEasy> BaronessMiniboss1Easy;
+    public static ConfigEntry<BaronessMinibossesEasy> BaronessMiniboss2Easy;
+    public static ConfigEntry<BaronessMinibossesEasy> BaronessMiniboss3Easy;
+    public static ConfigEntry<BaronessMinibossesNormal> BaronessMiniboss1Normal;
+    public static ConfigEntry<BaronessMinibossesNormal> BaronessMiniboss2Normal;
+    public static ConfigEntry<BaronessMinibossesNormal> BaronessMiniboss3Normal;
+    public static ConfigEntry<BaronessMinibossesHard> BaronessMiniboss1Hard;
+    public static ConfigEntry<BaronessMinibossesHard> BaronessMiniboss2Hard;
+    public static ConfigEntry<BaronessMinibossesHard> BaronessMiniboss3Hard;
+    public static ConfigEntry<FlyingBirdPhaseOneDirections> FlyingBirdPhaseOneDirection;
+    public static ConfigEntry<FlyingBirdPhaseOnePatternsEasy> FlyingBirdPhaseOnePatternEasy;
+    public static ConfigEntry<FlyingBirdPhaseTwoPatternsEasy> FlyingBirdPhaseTwoPatternEasy;
+    public static ConfigEntry<FlyingBirdPhaseOnePatternsNormal> FlyingBirdPhaseOnePatternNormal;
+    public static ConfigEntry<FlyingBirdPhaseTwoPatternsNormal> FlyingBirdPhaseTwoPatternNormal;
+    public static ConfigEntry<FlyingBirdPhaseOnePatternsHard> FlyingBirdPhaseOnePatternHard;
     public static ConfigEntry<FlyingBirdPhaseFinalPatterns> FlyingBirdPhaseFinalPattern;
     public static ConfigEntry<FlyingBirdPhaseFinalDirections> FlyingBirdPhaseFinalDirection;
     public static ConfigEntry<FlyingGeniePhaseOneTreasurePatterns> FlyingGeniePhaseOneTreasurePattern;
@@ -69,14 +99,39 @@ public class Settings : PluginComponent {
     public static ConfigEntry<BeePhaseTwoPatternsEasy> BeePhaseTwoPatternEasy;
     public static ConfigEntry<BeePhaseTwoPatternsNormal> BeePhaseTwoPatternNormal;
     public static ConfigEntry<BeePhaseTwoPatternsHard> BeePhaseTwoPatternHard;
+    public static ConfigEntry<RobotPhaseFinalGemColors> RobotPhaseFinalGemColor;
     public static ConfigEntry<MousePhaseOnePatternsEasy> MousePhaseOnePatternEasy;
     public static ConfigEntry<MousePhaseOnePatternsNormal> MousePhaseOnePatternNormal;
     public static ConfigEntry<MousePhaseOnePatternsHard> MousePhaseOnePatternHard;
+    public static ConfigEntry<PiratePhaseThreeGunPatternsEasy> PiratePhaseThreeGunPatternEasy;
+    public static ConfigEntry<PiratePhaseFourGunPatternsEasy> PiratePhaseFourGunPatternEasy;
+    public static ConfigEntry<PiratePhaseSevenGunPatternsEasy> PiratePhaseSevenGunPatternEasy;
+    public static ConfigEntry<PiratePhaseOneGunPatternsNormal> PiratePhaseOneGunPatternNormal;
+    public static ConfigEntry<PiratePhaseTwoGunPatternsNormal> PiratePhaseTwoGunPatternNormal;
+    public static ConfigEntry<PiratePhaseThreeGunPatternsNormal> PiratePhaseThreeGunPatternNormal;
+    public static ConfigEntry<PiratePhaseOneGunPatternsHard> PiratePhaseOneGunPatternHard;
+    public static ConfigEntry<PiratePhaseTwoGunPatternsHard> PiratePhaseTwoGunPatternHard;
+    public static ConfigEntry<PiratePhaseThreeGunPatternsHard> PiratePhaseThreeGunPatternHard;
+    public static ConfigEntry<PiratePhaseFourPatternsEasy> PiratePhaseFourPatternEasy;
+    public static ConfigEntry<PiratePhaseSevenPatternsEasy> PiratePhaseSevenPatternEasy;
+    public static ConfigEntry<PiratePhaseTwoPatternsNormalHard> PiratePhaseTwoPatternNormalHard;
+    public static ConfigEntry<PiratePhaseThreePatternsNormalHard> PiratePhaseThreePatternNormalHard;
     public static ConfigEntry<FlyingMermaidPhaseOneFirstPatternsEasy> FlyingMermaidPhaseOneFirstPatternEasy;
     public static ConfigEntry<FlyingMermaidPhaseOneSecondPatternsEasy> FlyingMermaidPhaseOneSecondPatternEasy;
     public static ConfigEntry<FlyingMermaidPhaseOnePatternsNormalHard> FlyingMermaidPhaseOnePatternNormalHard;
     public static ConfigEntry<FlyingMermaidPhaseOneFishPatterns> FlyingMermaidPhaseOneFishPattern;
     public static ConfigEntry<FlyingMermaidPhaseOneSummonPatterns> FlyingMermaidPhaseOneSummonPattern;
+    public static ConfigEntry<TrainPumpkinStartingDirections> TrainPumpkinStartingDirection;
+    public static ConfigEntry<TrainStartingGhouls> TrainStartingGhoul;
+    public static ConfigEntry<DicePalaceHeartPositions1> DicePalaceHeartPosition1;
+    public static ConfigEntry<DicePalaceHeartPositions2> DicePalaceHeartPosition2;
+    public static ConfigEntry<DicePalaceHeartPositions3> DicePalaceHeartPosition3;
+    public static ConfigEntry<DicePalaceCigarSpitAttackCountsNormal> DicePalaceCigarSpitAttackCountNormal;
+    public static ConfigEntry<DicePalaceCigarSpitAttackCountsHard> DicePalaceCigarSpitAttackCountHard;
+    public static ConfigEntry<DicePalaceRabbitPatterns> DicePalaceRabbitPattern;
+    public static ConfigEntry<DicePalaceRabbitParryDirections> DicePalaceRabbitParryDirection;
+    public static ConfigEntry<DicePalaceRoulettePatterns> DicePalaceRoulettePattern;
+    public static ConfigEntry<DicePalaceRouletteTwirlAmountsNormal> DicePalaceRouletteTwirlAmountNormal;
     public static ConfigEntry<DevilPhaseOnePatterns> DevilPhaseOnePattern;
     public static ConfigEntry<DevilPhaseOneHeadTypes> DevilPhaseOneHeadType;
     public static ConfigEntry<DevilPhaseOneDragonDirections> DevilPhaseOneDragonDirection;
@@ -87,7 +142,7 @@ public class Settings : PluginComponent {
     public static ConfigEntry<DevilPhaseTwoPatternsHard> DevilPhaseTwoPatternHard;
     public static ConfigEntry<DevilPhaseTwoBombEyeDirections> DevilPhaseTwoBombEyeDirection;
 
-    #if v1_3
+#if v1_3
     public static ConfigEntry<SaltbakerPhaseOnePatterns> SaltbakerPhaseOnePattern;
     public static ConfigEntry<SaltbakerPhaseThreeSawPatterns> SaltbakerPhaseThreeSawPattern;
 #endif
@@ -103,10 +158,10 @@ public class Settings : PluginComponent {
         PlatformHitboxes = config.Bind("Hitbox", "Platform Hitboxes", new KeyboardShortcut(KeyCode.P, KeyCode.LeftControl), --order);
         HighlightingHitboxes = config.Bind("Hitbox", "Highlighting Hitboxes", new KeyboardShortcut(KeyCode.B, KeyCode.LeftControl), --order);
 
-        MuteInBackground = config.Bind("Misc", "Mute In Background",false, --order);
-        RunInBackground = config.Bind("Misc", "Run In Background",false, --order);
-        IgnoreInputWhenLoseFocus = config.Bind("Misc", "Ignore Input When Lose Focus",false, --order);
-        SkipTitleScreen = config.Bind("Misc", "Skip Title Screen",true, --order);
+        MuteInBackground = config.Bind("Misc", "Mute In Background", false, --order);
+        RunInBackground = config.Bind("Misc", "Run In Background", false, --order);
+        IgnoreInputWhenLoseFocus = config.Bind("Misc", "Ignore Input When Lose Focus", false, --order);
+        SkipTitleScreen = config.Bind("Misc", "Skip Title Screen", true, --order);
         QuickRestart = config.Bind("Misc", "Quick Restart", new KeyboardShortcut(KeyCode.R), --order);
         LevelSelector = config.Bind("Misc", "Level Selector", new KeyboardShortcut(KeyCode.BackQuote), --order);
         Gain5ExCards = config.Bind("Misc", "Gain 5 Ex Cards", new KeyboardShortcut(KeyCode.Alpha1), --order);
@@ -118,8 +173,7 @@ public class Settings : PluginComponent {
         SwapBetweenFrameLimit = config.Bind("Misc", "Swap Between Frame Limit", new KeyboardShortcut(KeyCode.F5), --order);
         GuaranteeLobberExSweetSpot = config.Bind("Misc", "Guarantee Lobber Ex Sweet Spot", false, --order);
 
-        ToggleAllPanels = config.Bind("Panel", "Toggle All Panels", new KeyboardShortcut(KeyCode.F2), --order);
-        ToggleBetweenPanels = config.Bind("Panel", "Toggle Between Panels", new KeyboardShortcut(KeyCode.F3), --order);
+        ToggleBetweenPanels = config.Bind("Panel", "Toggle Between Panels", new KeyboardShortcut(KeyCode.F2), --order);
 
         CameraZoomIn = config.Bind("Camera", "Camera Zoom In", new KeyboardShortcut(KeyCode.PageUp, KeyCode.LeftControl), --order);
         CameraZoomOut = config.Bind("Camera", "Camera Zoom Out", new KeyboardShortcut(KeyCode.PageDown, KeyCode.LeftControl), --order);
@@ -128,7 +182,7 @@ public class Settings : PluginComponent {
         AllowRecollectCoins = config.Bind("Coin", "Allow Recollect Coins", true, --order);
         ReduceCurrency = config.Bind("Coin", "Reduce Coin", new KeyboardShortcut(KeyCode.Alpha5), --order);
         AddCurrency = config.Bind("Coin", "Add Coin", new KeyboardShortcut(KeyCode.Alpha6), --order);
-        
+
         DecreaseSpeed = config.Bind("Game Speed", "Decrease Game Speed", new KeyboardShortcut(KeyCode.Minus), --order);
         IncreaseSpeed = config.Bind("Game Speed", "Increase Game Speed", new KeyboardShortcut(KeyCode.Plus), --order);
         ResetSpeed = config.Bind("Game Speed", "Reset Game Speed", new KeyboardShortcut(KeyCode.Alpha0), --order);
@@ -136,11 +190,28 @@ public class Settings : PluginComponent {
         FrameAdvance = config.Bind("Game Speed", "Frame Advance", new KeyboardShortcut(KeyCode.LeftBracket), --order);
 
 
-        #if v1_3
+        RTATime = config.Bind("InfoHUD", "RTA Time", true, --order);
+        IGTTime = config.Bind("InfoHUD", "IGT Time", true, --order);
+        WeaponCooldowns = config.Bind("InfoHUD", "Weapon Cooldowns", true, --order);
+        OnEXWeaponCooldown = config.Bind("InfoHUD", "Weapon Cooldown on EX", true, --order);
+        Goal = config.Bind("InfoHUD", "Goal", false, --order);
+        Parries = config.Bind("InfoHUD", "Parries", false, --order);
+        Supers = config.Bind("InfoHUD", "Supers", false, --order);
+        Damage = config.Bind("InfoHUD", "Damage", false, --order);
+        CurrentRank = config.Bind("InfoHUD", "Current Rank", false, --order);
+        Difficulty = config.Bind("InfoHUD", "Difficulty", false, --order);
+        DmgMultiplier = config.Bind("InfoHUD", "Damage Multiplier", false, --order);
+        PlayerCount = config.Bind("InfoHUD", "Player Count", false, --order);
+        CurrentScene = config.Bind("InfoHUD", "Current Scene", false, --order);
+
+#if v1_3
         RelicLevel = config.Bind("DLC", "Relic Level", RelicLevels.Default);
-        #endif
+#endif
 
         FrogsPhaseOnePattern = config.Bind("RNG Ribby And Croaks", "Phase One Pattern", FrogsPhaseOnePatterns.Random, --order);
+        FrogsPhaseOneFirefliesPatternEasy = config.Bind("RNG Ribby And Croaks", "Phase One Fireflies Pattern Simple", FrogsPhaseOneFirefliesPatternsEasy.Random, --order);
+        FrogsPhaseOneFirefliesPatternNormal = config.Bind("RNG Ribby And Croaks", "Phase One Fireflies Pattern Regular", FrogsPhaseOneFirefliesPatternsNormal.Random, --order);
+        FrogsPhaseOneFirefliesPatternHard = config.Bind("RNG Ribby And Croaks", "Phase One Fireflies Pattern Expert", FrogsPhaseOneFirefliesPatternsHard.Random, --order);
         FrogsPhaseFinalPattern = config.Bind("RNG Ribby And Croaks", "Final Phase Pattern", FrogsPhaseFinalPatterns.Random, --order);
         FlyingBlimpPhaseBlimp2PatternEasy = config.Bind("RNG Hilda Berg", "Second Blimp Phase Simple", FlyingBlimpPhaseBlimp2PatternsEasy.Random, --order);
         FlyingBlimpPhaseBlimp3PatternEasy = config.Bind("RNG Hilda Berg", "Third Blimp Phase Simple", FlyingBlimpPhaseBlimp3PatternsEasy.Random, --order);
@@ -152,6 +223,21 @@ public class Settings : PluginComponent {
         FlowerPhaseGeneric2PatternNormal = config.Bind("RNG Cagney Carnation", "Second Generic Phase Regular", FlowerPhaseGeneric2PatternsNormal.Random, --order);
         FlowerPhaseGeneric3PatternNormal = config.Bind("RNG Cagney Carnation", "Third Generic Phase Regular", FlowerPhaseGeneric3PatternsNormal.Random, --order);
         FlowerPhaseGenericHeadLungePatternNormal = config.Bind("RNG Cagney Carnation", "Generic Phase Head Lunge Regular", FlowerPhaseGenericHeadLungePatternsNormal.Random, --order);
+        BaronessMiniboss1Easy = config.Bind("RNG Baroness Von Bon Bon", "Miniboss 1 Simple", BaronessMinibossesEasy.Random, --order);
+        BaronessMiniboss2Easy = config.Bind("RNG Baroness Von Bon Bon", "Miniboss 2 Simple", BaronessMinibossesEasy.Random, --order);
+        BaronessMiniboss3Easy = config.Bind("RNG Baroness Von Bon Bon", "Miniboss 3 Simple", BaronessMinibossesEasy.Random, --order);
+        BaronessMiniboss1Normal = config.Bind("RNG Baroness Von Bon Bon", "Miniboss 1 Regular", BaronessMinibossesNormal.Random, --order);
+        BaronessMiniboss2Normal = config.Bind("RNG Baroness Von Bon Bon", "Miniboss 2 Regular", BaronessMinibossesNormal.Random, --order);
+        BaronessMiniboss3Normal = config.Bind("RNG Baroness Von Bon Bon", "Miniboss 3 Regular", BaronessMinibossesNormal.Random, --order);
+        BaronessMiniboss1Hard = config.Bind("RNG Baroness Von Bon Bon", "Miniboss 1 Expert", BaronessMinibossesHard.Random, --order);
+        BaronessMiniboss2Hard = config.Bind("RNG Baroness Von Bon Bon", "Miniboss 2 Expert", BaronessMinibossesHard.Random, --order);
+        BaronessMiniboss3Hard = config.Bind("RNG Baroness Von Bon Bon", "Miniboss 3 Expert", BaronessMinibossesHard.Random, --order);
+        FlyingBirdPhaseOneDirection = config.Bind("RNG Wally Warbles", "Phase One Direction", FlyingBirdPhaseOneDirections.Random, --order);
+        FlyingBirdPhaseOnePatternEasy = config.Bind("RNG Wally Warbles", "Phase One Pattern Simple", FlyingBirdPhaseOnePatternsEasy.Random, --order);
+        FlyingBirdPhaseTwoPatternEasy = config.Bind("RNG Wally Warbles", "Phase Two Pattern Simple", FlyingBirdPhaseTwoPatternsEasy.Random, --order);
+        FlyingBirdPhaseOnePatternNormal = config.Bind("RNG Wally Warbles", "Phase One Pattern Regular", FlyingBirdPhaseOnePatternsNormal.Random, --order);
+        FlyingBirdPhaseTwoPatternNormal = config.Bind("RNG Wally Warbles", "Phase Two Pattern Regular", FlyingBirdPhaseTwoPatternsNormal.Random, --order);
+        FlyingBirdPhaseOnePatternHard = config.Bind("RNG Wally Warbles", "Phase One Pattern Expert", FlyingBirdPhaseOnePatternsHard.Random, --order);
         FlyingBirdPhaseFinalPattern = config.Bind("RNG Wally Warbles", "Final Phase Pattern", FlyingBirdPhaseFinalPatterns.Random, --order);
         FlyingBirdPhaseFinalDirection = config.Bind("RNG Wally Warbles", "Final Phase Direction", FlyingBirdPhaseFinalDirections.Random, --order);
         FlyingGeniePhaseOneTreasurePattern = config.Bind("RNG Djimmi The Great", "First Phase Treasure", FlyingGeniePhaseOneTreasurePatterns.Random, --order);
@@ -161,14 +247,39 @@ public class Settings : PluginComponent {
         BeePhaseTwoPatternEasy = config.Bind("RNG Rumor Honeybottoms", "Phase Two Simple", BeePhaseTwoPatternsEasy.Random, --order);
         BeePhaseTwoPatternNormal = config.Bind("RNG Rumor Honeybottoms", "Phase Two Regular", BeePhaseTwoPatternsNormal.Random, --order);
         BeePhaseTwoPatternHard = config.Bind("RNG Rumor Honeybottoms", "Phase Two Expert", BeePhaseTwoPatternsHard.Random, --order);
+        RobotPhaseFinalGemColor = config.Bind("RNG Dr. Kahls Robot", "Final Phase Gem Color", RobotPhaseFinalGemColors.Random, --order);
         MousePhaseOnePatternEasy = config.Bind("RNG Werner Werman", "Phase One Simple", MousePhaseOnePatternsEasy.Random, --order);
         MousePhaseOnePatternNormal = config.Bind("RNG Werner Werman", "Phase One Regular", MousePhaseOnePatternsNormal.Random, --order);
         MousePhaseOnePatternHard = config.Bind("RNG Werner Werman", "Phase One Expert", MousePhaseOnePatternsHard.Random, --order);
+        PiratePhaseThreeGunPatternEasy = config.Bind("RNG Captain Brineybeard", "Phase Three Gun Simple", PiratePhaseThreeGunPatternsEasy.Random, --order);
+        PiratePhaseFourGunPatternEasy = config.Bind("RNG Captain Brineybeard", "Phase Four Gun Simple", PiratePhaseFourGunPatternsEasy.Random, --order);
+        PiratePhaseSevenGunPatternEasy = config.Bind("RNG Captain Brineybeard", "Phase Seven Gun Simple", PiratePhaseSevenGunPatternsEasy.Random, --order);
+        PiratePhaseOneGunPatternNormal = config.Bind("RNG Captain Brineybeard", "Phase One Gun Regular", PiratePhaseOneGunPatternsNormal.Random, --order);
+        PiratePhaseTwoGunPatternNormal = config.Bind("RNG Captain Brineybeard", "Phase Two Gun Regular", PiratePhaseTwoGunPatternsNormal.Random, --order);
+        PiratePhaseThreeGunPatternNormal = config.Bind("RNG Captain Brineybeard", "Phase Three Gun Regular", PiratePhaseThreeGunPatternsNormal.Random, --order);
+        PiratePhaseOneGunPatternHard = config.Bind("RNG Captain Brineybeard", "Phase One Gun Expert", PiratePhaseOneGunPatternsHard.Random, --order);
+        PiratePhaseTwoGunPatternHard = config.Bind("RNG Captain Brineybeard", "Phase Two Gun Expert", PiratePhaseTwoGunPatternsHard.Random, --order);
+        PiratePhaseThreeGunPatternHard = config.Bind("RNG Captain Brineybeard", "Phase Three Gun Expert", PiratePhaseThreeGunPatternsHard.Random, --order);
+        PiratePhaseFourPatternEasy = config.Bind("RNG Captain Brineybeard", "Phase Four Simple", PiratePhaseFourPatternsEasy.Random, --order);
+        PiratePhaseSevenPatternEasy = config.Bind("RNG Captain Brineybeard", "Phase Seven Simple", PiratePhaseSevenPatternsEasy.Random, --order);
+        PiratePhaseTwoPatternNormalHard = config.Bind("RNG Captain Brineybeard", "Phase Two Regular/Expert", PiratePhaseTwoPatternsNormalHard.Random, --order);
+        PiratePhaseThreePatternNormalHard = config.Bind("RNG Captain Brineybeard", "Phase Three Regular/Expert", PiratePhaseThreePatternsNormalHard.Random, --order);
         FlyingMermaidPhaseOneFirstPatternEasy = config.Bind("RNG Cala Maria", "Phase One First Simple", FlyingMermaidPhaseOneFirstPatternsEasy.Random, --order);
         FlyingMermaidPhaseOneSecondPatternEasy = config.Bind("RNG Cala Maria", "Phase One Second Simple", FlyingMermaidPhaseOneSecondPatternsEasy.Random, --order);
         FlyingMermaidPhaseOnePatternNormalHard = config.Bind("RNG Cala Maria", "Phase One Regular/Expert", FlyingMermaidPhaseOnePatternsNormalHard.Random, --order);
         FlyingMermaidPhaseOneFishPattern = config.Bind("RNG Cala Maria", "Phase One Fish", FlyingMermaidPhaseOneFishPatterns.Random, --order);
         FlyingMermaidPhaseOneSummonPattern = config.Bind("RNG Cala Maria", "Phase One Summon", FlyingMermaidPhaseOneSummonPatterns.Random, --order);
+        TrainPumpkinStartingDirection = config.Bind("RNG Phantom Express", "Pumpkin Starting Direction", TrainPumpkinStartingDirections.Random, --order);
+        TrainStartingGhoul = config.Bind("RNG Phantom Express", "Starting Ghoul", TrainStartingGhouls.Random, --order);
+        DicePalaceHeartPosition1 = config.Bind("RNG King Dice", "First Heart", DicePalaceHeartPositions1.Random, --order);
+        DicePalaceHeartPosition2 = config.Bind("RNG King Dice", "Second Heart", DicePalaceHeartPositions2.Random, --order);
+        DicePalaceHeartPosition3 = config.Bind("RNG King Dice", "Third Heart", DicePalaceHeartPositions3.Random, --order);
+        DicePalaceCigarSpitAttackCountNormal = config.Bind("RNG King Dice", "Mr. Wheezy Attack Count Regular", DicePalaceCigarSpitAttackCountsNormal.Random, --order);
+        DicePalaceCigarSpitAttackCountHard = config.Bind("RNG King Dice", "Mr. Wheezy Attack Count Expert", DicePalaceCigarSpitAttackCountsHard.Random, --order);
+        DicePalaceRabbitPattern = config.Bind("RNG King Dice", "Mangosteen Pattern", DicePalaceRabbitPatterns.Random, --order);
+        DicePalaceRabbitParryDirection = config.Bind("RNG King Dice", "Mangosteen Parry Direction", DicePalaceRabbitParryDirections.Random, --order);
+        DicePalaceRoulettePattern = config.Bind("RNG King Dice", "Pirouletta Pattern", DicePalaceRoulettePatterns.Random, --order);
+        DicePalaceRouletteTwirlAmountNormal = config.Bind("RNG King Dice", "Pirouletta Twirl Amount Regular", DicePalaceRouletteTwirlAmountsNormal.Random, --order);
         DevilPhaseOnePattern = config.Bind("RNG The Devil", "Phase One Pattern", DevilPhaseOnePatterns.Random, --order);
         DevilPhaseOneHeadType = config.Bind("RNG The Devil", "Phase One Head Type", DevilPhaseOneHeadTypes.Random, --order);
         DevilPhaseOneDragonDirection = config.Bind("RNG The Devil", "Phase One Dragon Direction", DevilPhaseOneDragonDirections.Random, --order);
@@ -179,7 +290,7 @@ public class Settings : PluginComponent {
         DevilPhaseTwoPatternHard = config.Bind("RNG The Devil", "Phase Two Expert", DevilPhaseTwoPatternsHard.Random, --order);
         DevilPhaseTwoBombEyeDirection = config.Bind("RNG The Devil", "Phase Two Bomb Direction", DevilPhaseTwoBombEyeDirections.Random, --order);
 
-        #if v1_3
+#if v1_3
         SaltbakerPhaseOnePattern = config.Bind("RNG Chef Saltbaker", "Phase One Pattern", SaltbakerPhaseOnePatterns.Random, --order);
         SaltbakerPhaseThreeSawPattern = config.Bind("RNG Chef Saltbaker", "Phase Three Saw Pattern", SaltbakerPhaseThreeSawPatterns.Random, --order);
 #endif

--- a/Cuphead.DebugMod/Config/Settings.cs
+++ b/Cuphead.DebugMod/Config/Settings.cs
@@ -79,6 +79,7 @@ public class Settings : PluginComponent {
     public static ConfigEntry<DevilPhaseOneHeadTypes> DevilPhaseOneHeadType;
     public static ConfigEntry<DevilPhaseOneDragonDirections> DevilPhaseOneDragonDirection;
     public static ConfigEntry<DevilPhaseOneSpiderOffsets> DevilPhaseOneSpiderOffset;
+    public static ConfigEntry<DevilPhaseOneSpiderHopCounts> DevilPhaseOneSpiderHopCount;
     public static ConfigEntry<DevilPhaseOnePitchforkTypes> DevilPhaseOnePitchforkType;
     public static ConfigEntry<DevilPhaseTwoPatternsNormal> DevilPhaseTwoPatternNormal;
     public static ConfigEntry<DevilPhaseTwoPatternsHard> DevilPhaseTwoPatternHard;
@@ -169,6 +170,7 @@ public class Settings : PluginComponent {
         DevilPhaseOneHeadType = config.Bind("RNG The Devil", "Phase One Head Type", DevilPhaseOneHeadTypes.Random, --order);
         DevilPhaseOneDragonDirection = config.Bind("RNG The Devil", "Phase One Dragon Direction", DevilPhaseOneDragonDirections.Random, --order);
         DevilPhaseOneSpiderOffset = config.Bind("RNG The Devil", "Phase One Spider Offset", DevilPhaseOneSpiderOffsets.Random, --order);
+        DevilPhaseOneSpiderHopCount = config.Bind("RNG The Devil", "Phase One Spider Hop Count", DevilPhaseOneSpiderHopCounts.Random, --order);
         DevilPhaseOnePitchforkType = config.Bind("RNG The Devil", "Phase One Pitchfork Type", DevilPhaseOnePitchforkTypes.Random, --order);
         DevilPhaseTwoPatternNormal = config.Bind("RNG The Devil", "Phase Two Regular", DevilPhaseTwoPatternsNormal.Random, --order);
         DevilPhaseTwoPatternHard = config.Bind("RNG The Devil", "Phase Two Expert", DevilPhaseTwoPatternsHard.Random, --order);

--- a/Cuphead.DebugMod/Config/Settings.cs
+++ b/Cuphead.DebugMod/Config/Settings.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using BepInEx.Configuration;
+using BepInEx.CupheadDebugMod.Components;
 using UnityEngine;
 using static BepInEx.CupheadDebugMod.Config.SettingsEnums;
 
@@ -15,6 +16,7 @@ public class Settings : PluginComponent {
     public static ConfigEntry<bool> RunInBackground;
     public static ConfigEntry<bool> IgnoreInputWhenLoseFocus;
     public static ConfigEntry<bool> SkipTitleScreen;
+    public static ConfigEntry<bool> GuaranteeLobberExSweetSpot;
     public static ConfigEntry<KeyboardShortcut> InvincibilityOneFight;
     public static ConfigEntry<KeyboardShortcut> Gain5ExCards;
     public static ConfigEntry<KeyboardShortcut> Gain1ExCard;
@@ -114,6 +116,7 @@ public class Settings : PluginComponent {
         InvincibilityOneFight = config.Bind("Misc", "Invincibility One Fight", new KeyboardShortcut(KeyCode.Alpha5), --order);
         ToggleFrameCounter = config.Bind("Misc", "Toggle FrameCounter", new KeyboardShortcut(KeyCode.F4), --order);
         SwapBetweenFrameLimit = config.Bind("Misc", "Swap Between Frame Limit", new KeyboardShortcut(KeyCode.F5), --order);
+        GuaranteeLobberExSweetSpot = config.Bind("Misc", "Guarantee Lobber Ex Sweet Spot", false, --order);
 
         ToggleAllPanels = config.Bind("Panel", "Toggle All Panels", new KeyboardShortcut(KeyCode.F2), --order);
         ToggleBetweenPanels = config.Bind("Panel", "Toggle Between Panels", new KeyboardShortcut(KeyCode.F3), --order);

--- a/Cuphead.DebugMod/Config/SettingsEnums.cs
+++ b/Cuphead.DebugMod/Config/SettingsEnums.cs
@@ -1,13 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Text;
+﻿using System.ComponentModel;
 
 namespace BepInEx.CupheadDebugMod.Config {
     public static class SettingsEnums {
 
-        #if v1_3
+#if v1_3
         public enum RelicLevels {
             Default,
             BrokenRelic,
@@ -21,13 +17,53 @@ namespace BepInEx.CupheadDebugMod.Config {
             CursedRelic4,
             DivineRelic
         }
-        #endif
+#endif
 
         public enum FrogsPhaseOnePatterns {
             Random,
             Punches,
             Fireflies
         }
+
+        public enum FrogsPhaseOneFirefliesPatternsEasy {
+            Random,
+            [Description("2-1-1 (Slow)")]
+            Two_One_One_Slow,
+            [Description("1-1-2")]
+            One_One_Two,
+            [Description("2-1-1 (Fast)")]
+            Two_One_One_Fast
+        }
+        public enum FrogsPhaseOneFirefliesPatternsNormal {
+            Random,
+            [Description("2-2-1-2")]
+            Two_Two_One_Two,
+            [Description("2-2-2")]
+            Two_Two_Two,
+            [Description("2-1-2-2")]
+            Two_One_Two_Two,
+            [Description("2-2-1")]
+            Two_Two_One,
+        }
+
+        public enum FrogsPhaseOneFirefliesPatternsHard {
+            Random,
+            [Description("2-2-1")]
+            Two_Two_One,
+            [Description("1-1-2")]
+            One_One_Two,
+            [Description("2-2 (Fast)")]
+            Two_Two_Fast,
+            [Description("2-1-1")]
+            Two_One_One,
+            [Description("1-2-2")]
+            One_Two_Two,
+            [Description("2-2 (Slow)")]
+            Two_Two_Slow,
+            [Description("1-2-1")]
+            One_Two_One
+        }
+
         public enum FrogsPhaseFinalPatterns {
             Random,
             Snake,
@@ -121,6 +157,145 @@ namespace BepInEx.CupheadDebugMod.Config {
             Top3,
             Bottom5,
             Bottom6
+        }
+
+        public enum BaronessMinibossesEasy {
+            Random,
+            Gumball,
+            Waffle,
+            CandyCorn,
+            Jawbreaker
+        }
+
+        public enum BaronessMinibossesNormal {
+            Random,
+            Gumball,
+            Waffle,
+            CandyCorn,
+            Cupcake,
+            Jawbreaker
+        }
+
+        public enum BaronessMinibossesHard {
+            Random,
+            Gumball,
+            Waffle,
+            CandyCorn,
+            Cupcake,
+            Jawbreaker
+        }
+
+        public enum FlyingBirdPhaseOneDirections {
+            Random,
+            Up,
+            Down
+        }
+
+
+        public enum FlyingBirdPhaseOnePatternsEasy {
+            Random,
+            [Description("Eggs")]
+            Eggs1,
+            [Description("Lasers")]
+            Lasers1,
+            [Description("Eggs")]
+            Eggs2,
+            [Description("Eggs")]
+            Eggs3,
+            [Description("Lasers")]
+            Lasers2
+        }
+
+        public enum FlyingBirdPhaseTwoPatternsEasy {
+            Random,
+            [Description("Eggs")]
+            Eggs1,
+            [Description("Eggs")]
+            Eggs2,
+            [Description("Eggs")]
+            Eggs3,
+            [Description("Lasers")]
+            Lasers1,
+            [Description("Eggs")]
+            Eggs4,
+            [Description("Eggs")]
+            Eggs5,
+            [Description("Eggs")]
+            Eggs6,
+            [Description("Eggs")]
+            Eggs7,
+            [Description("Lasers")]
+            Lasers2
+        }
+
+        public enum FlyingBirdPhaseOnePatternsNormal {
+            Random,
+            [Description("Eggs")]
+            Eggs1,
+            [Description("Lasers")]
+            Lasers1
+        }
+
+        public enum FlyingBirdPhaseTwoPatternsNormal {
+            Random,
+            [Description("Eggs")]
+            Eggs1,
+            [Description("Eggs")]
+            Eggs2,
+            [Description("Eggs")]
+            Eggs3,
+            [Description("Lasers")]
+            Lasers1,
+            [Description("Eggs")]
+            Eggs4,
+            [Description("Eggs")]
+            Eggs5,
+            [Description("Eggs")]
+            Eggs6,
+            [Description("Eggs")]
+            Eggs7,
+            [Description("Lasers")]
+            Lasers2
+        }
+
+        public enum FlyingBirdPhaseOnePatternsHard {
+            Random,
+            [Description("Eggs")]
+            Eggs01,
+            [Description("Eggs")]
+            Eggs02,
+            [Description("Eggs")]
+            Eggs03,
+            [Description("Lasers")]
+            Lasers01,
+            [Description("Eggs")]
+            Eggs04,
+            [Description("Eggs")]
+            Eggs05,
+            [Description("Lasers")]
+            Lasers02,
+            [Description("Eggs")]
+            Eggs06,
+            [Description("Eggs")]
+            Eggs07,
+            [Description("Eggs")]
+            Eggs08,
+            [Description("Lasers")]
+            Lasers03,
+            [Description("Eggs")]
+            Eggs09,
+            [Description("Eggs")]
+            Eggs10,
+            [Description("Lasers")]
+            Lasers04,
+            [Description("Eggs")]
+            Eggs11,
+            [Description("Eggs")]
+            Eggs12,
+            [Description("Eggs")]
+            Eggs13,
+            [Description("Lasers")]
+            Lasers05,
         }
 
         public enum FlyingBirdPhaseFinalPatterns {
@@ -244,6 +419,12 @@ namespace BepInEx.CupheadDebugMod.Config {
             Chain2
         }
 
+        public enum RobotPhaseFinalGemColors {
+            Random,
+            Red,
+            Blue
+        }
+
         public enum MousePhaseOnePatternsEasy {
             Random,
             Dash1,
@@ -288,6 +469,174 @@ namespace BepInEx.CupheadDebugMod.Config {
             Dash4
         }
 
+        public enum PiratePhaseThreeGunPatternsEasy {
+            Random,
+            [Description("1-2")]
+            One_Two,
+            [Description("2-1")]
+            Two_One,
+            [Description("3")]
+            Three
+        }
+
+        public enum PiratePhaseFourGunPatternsEasy {
+            Random,
+            [Description("1-1 #1")]
+            One_One_1,
+            [Description("1-1 #2")]
+            One_One_2,
+            [Description("2 (Double as likely!)")]
+            Two,
+            [Description("1-1 Longer")]
+            One_One_Longer,
+            [Description("1-1 Shorter")]
+            One_One_Shorter
+        }
+
+        public enum PiratePhaseSevenGunPatternsEasy {
+            Random,
+            [Description("2-1-2 #1")]
+            Two_One_Two_1,
+            [Description("2-2-1 (Double as likely!)")]
+            Two_Two_One,
+            [Description("3")]
+            Three,
+            [Description("1-2-2")]
+            One_Two_Two,
+            [Description("1-3")]
+            One_Three,
+            [Description("2-1-2 #2")]
+            Two_One_Two_2,
+            [Description("4")]
+            Four
+        }
+
+        public enum PiratePhaseOneGunPatternsNormal {
+            Random,
+            [Description("3-1")]
+            Three_One,
+            [Description("2-2")]
+            Two_Two,
+            [Description("1-3")]
+            One_Three
+        }
+
+        public enum PiratePhaseTwoGunPatternsNormal {
+            Random,
+            [Description("1-1-2")]
+            One_One_Two,
+            [Description("2-1-1 (Bugged!)")]
+            Two_One_One
+        }
+
+        public enum PiratePhaseThreeGunPatternsNormal {
+            Random,
+            [Description("2-1")]
+            Two_One,
+            [Description("1-2")]
+            One_Two,
+        }
+
+        public enum PiratePhaseOneGunPatternsHard {
+            Random,
+            [Description("2-3 Longer")]
+            Two_Three_Longer,
+            [Description("2-3 Shorter")]
+            Two_Three_Shorter,
+            [Description("3-2 #1")]
+            Three_Two_1,
+            [Description("3-2 #2")]
+            Three_Two_2,
+            [Description("4")]
+            Four
+        }
+
+        public enum PiratePhaseTwoGunPatternsHard {
+            Random,
+            [Description("3-1")]
+            Three_One,
+            [Description("4 (Double as likely!)")]
+            Four,
+            [Description("2-2")]
+            Two_Two,
+            [Description("1-3")]
+            One_Three
+        }
+
+        public enum PiratePhaseThreeGunPatternsHard {
+            Random,
+            [Description("2 (Double as likely!)")]
+            Two,
+            [Description("3")]
+            Three,
+            [Description("4")]
+            Four
+        }
+
+        public enum PiratePhaseFourPatternsEasy {
+            Random,
+            Peashot,
+            Shark
+        }
+
+        public enum PiratePhaseSevenPatternsEasy {
+            Random,
+            [Description("Peashot")]
+            Peashot01,
+            [Description("Peashot")]
+            Peashot02,
+            [Description("Peashot")]
+            Peashot03,
+            [Description("Shark")]
+            Shark01,
+            [Description("Peashot")]
+            Peashot04,
+            [Description("Peashot")]
+            Peashot05,
+            [Description("Shark")]
+            Shark02,
+            [Description("Peashot")]
+            Peashot06,
+            [Description("Peashot")]
+            Peashot07,
+            [Description("Shark")]
+            Shark03,
+            [Description("Peashot")]
+            Peashot08,
+            [Description("Peashot")]
+            Peashot09,
+            [Description("Peashot")]
+            Peashot10,
+            [Description("Shark")]
+            Shark04,
+        }
+
+        public enum PiratePhaseTwoPatternsNormalHard {
+            Random,
+            [Description("Peashot -> Shark")]
+            PeashotShark,
+            Shark,
+            [Description("Peashot -> Squid")]
+            PeashotSquid,
+            Squid,
+            [Description("Peashot -> Dogfish")]
+            PeashotDogfish,
+            Dogfish
+        }
+
+        public enum PiratePhaseThreePatternsNormalHard {
+            Random,
+            [Description("Peashot -> Shark")]
+            PeashotShark,
+            Shark,
+            [Description("Peashot -> Squid")]
+            PeashotSquid,
+            Squid,
+            [Description("Peashot -> Dogfish")]
+            PeashotDogfish,
+            Dogfish
+        }
+
         public enum FlyingMermaidPhaseOneFirstPatternsEasy {
             Random,
             Ghosts,
@@ -319,6 +668,158 @@ namespace BepInEx.CupheadDebugMod.Config {
             Seahorse,
             Pufferfish,
             Turtle
+        }
+
+        public enum TrainPumpkinStartingDirections {
+            Random,
+            Left,
+            Right
+        }
+
+        public enum TrainStartingGhouls {
+            Random,
+            Left,
+            Right
+        }
+
+        public enum DicePalaceHeartPositions1 {
+            Random,
+            [Description("1")]
+            One,
+            [Description("2")]
+            Two,
+            [Description("3")]
+            Three
+        }
+
+        public enum DicePalaceHeartPositions2 {
+            Random,
+            [Description("4")]
+            Four,
+            [Description("5")]
+            Five,
+            [Description("6")]
+            Six
+        }
+
+        public enum DicePalaceHeartPositions3 {
+            Random,
+            [Description("7")]
+            Seven,
+            [Description("8")]
+            Eight,
+            [Description("9")]
+            Nine
+        }
+
+        public enum DicePalaceCigarSpitAttackCountsNormal {
+            Random,
+            [Description("1")]
+            One1,
+            [Description("2")]
+            Two1,
+            [Description("1")]
+            One2,
+            [Description("2")]
+            Two2,
+            [Description("2")]
+            Two3,
+            [Description("3")]
+            Three1,
+            [Description("1")]
+            One3,
+            [Description("2")]
+            Two4,
+        }
+
+        public enum DicePalaceCigarSpitAttackCountsHard {
+            Random,
+            [Description("2")]
+            Two1,
+            [Description("1")]
+            One1,
+            [Description("3")]
+            Three1,
+            [Description("2")]
+            Two2,
+            [Description("3")]
+            Three2,
+            [Description("1")]
+            One2,
+            [Description("3")]
+            Three3,
+            [Description("3")]
+            Three4,
+            [Description("2")]
+            Two3,
+        }
+
+        public enum DicePalaceRabbitPatterns {
+            Random,
+            [Description("Wand")]
+            Wand01,
+            [Description("Parry")]
+            Parry01,
+            [Description("Wand")]
+            Wand02,
+            [Description("Wand")]
+            Wand03,
+            [Description("Parry")]
+            Parry02,
+            [Description("Wand")]
+            Wand04,
+            [Description("Wand")]
+            Wand05,
+            [Description("Parry")]
+            Parry03,
+            [Description("Wand")]
+            Wand06,
+            [Description("Parry")]
+            Parry04,
+            [Description("Wand")]
+            Wand07,
+            [Description("Parry")]
+            Parry05,
+            [Description("Wand")]
+            Wand08,
+            [Description("Wand")]
+            Wand09,
+            [Description("Parry")]
+            Parry06,
+            [Description("Wand")]
+            Wand10,
+            [Description("Wand")]
+            Wand11,
+            [Description("Wand")]
+            Wand12,
+            [Description("Parry")]
+            Parry07,
+            [Description("Wand")]
+            Wand13,
+            [Description("Wand")]
+            Wand14,
+            [Description("Parry")]
+            Parry08
+        }
+
+        public enum DicePalaceRabbitParryDirections {
+            Random,
+            Top,
+            Bottom
+        }
+
+        public enum DicePalaceRoulettePatterns {
+            Random,
+            Twirl,
+            Marble
+        }
+
+        public enum DicePalaceRouletteTwirlAmountsNormal {
+            Random,
+            [Description("4")]
+            Four,
+            [Description("5")]
+            Five
         }
 
         public enum DevilPhaseOnePatterns {
@@ -450,7 +951,7 @@ namespace BepInEx.CupheadDebugMod.Config {
             SkullEye09,
         }
 
-        public enum DevilPhaseTwoBombEyeDirections { 
+        public enum DevilPhaseTwoBombEyeDirections {
             Random,
             Left,
             Right

--- a/Cuphead.DebugMod/Config/SettingsEnums.cs
+++ b/Cuphead.DebugMod/Config/SettingsEnums.cs
@@ -394,6 +394,18 @@ namespace BepInEx.CupheadDebugMod.Config {
             [Description("0")]
             T_0
         }
+
+        public enum DevilPhaseOneSpiderHopCounts {
+            Random,
+            [Description("3")]
+            Num_3,
+            [Description("4")]
+            Num_4,
+            [Description("5")]
+            Num_5
+
+        }
+
         public enum DevilPhaseTwoPatternsNormal {
             Random,
             BombEye01,

--- a/Cuphead.DebugMod/Cuphead.DebugMod.csproj
+++ b/Cuphead.DebugMod/Cuphead.DebugMod.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net35</TargetFramework>
         <AssemblyName>Cuphead.DebugMod</AssemblyName>
         <Description>Cuphead plugin provides several features</Description>
-        <Version>1.3.0</Version>
+        <Version>1.4.0</Version>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <LangVersion>latest</LangVersion>
         <RestoreAdditionalProjectSources>
@@ -16,7 +16,7 @@
         <RootNamespace>BepInEx.CupheadDebugMod</RootNamespace>
         <Optimize>true</Optimize>
         <PathMap>$(MSBuildProjectDirectory)=CupheadDebugMod/</PathMap>
-        <PackageVersion>1.3.0</PackageVersion>
+        <PackageVersion>1.4.0</PackageVersion>
         <RunPostBuildEvent>Always</RunPostBuildEvent>
     </PropertyGroup>
 

--- a/Cuphead.DebugMod/PluginComponent.cs
+++ b/Cuphead.DebugMod/PluginComponent.cs
@@ -26,7 +26,7 @@ public abstract class PluginComponent : MonoBehaviour {
             PreviousSceneName = CurrentSceneName;
             CurrentSceneName = nextScene.name;
         });
-        
+
         List<Type> componentTypes = Assembly.GetExecutingAssembly().GetTypes()
             .Where(type => !type.IsAbstract && type.IsSubclassOf(typeof(PluginComponent))).ToList();
         componentTypes.Sort((type, otherType) => GetPriority(otherType) - GetPriority(type));


### PR DESCRIPTION
Apologies for the big dump of stuff :P

This PR primarily adds a lot more RNG control options.

Additionally, it reworks how the infoHUD works. It now only allows toggling between panels with a single button, but allows the info displayed within it to be customizable within the BepInEx menu.

There are also a couple new options that can be added on the infoHUD that allow display of information pertaining to weapon cooldown:
- A live display of the cooldown for the currently equipped weapons.
- A display of what the cooldown for a weapon was upon the moment an EX move is fired (primarily useful for Cuphead versions 1.1 and above).
(The weapon cooldown code was mostly readapted for the TAS repository)

A lot of changes in individual files are just the results of running Code Cleanup within Visual Studio (remove unnecessary usings, formatting, etc.).